### PR TITLE
Make css enqueueable

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,8 +6,8 @@ if ( ! isset( $content_width ) ) {
 }
 
 if ( function_exists('add_theme_support') ) {
-    // Adding theme support for HTML5
-    add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption' ) );
+	// Adding theme support for HTML5
+	add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption', ) );
 	// Adds site name to title tag
 	add_theme_support( 'title-tag' );
 	// Add support for automatic links for feeds.
@@ -21,7 +21,7 @@ if ( function_exists('add_theme_support') ) {
 }
 
 
-function gesso_nav($location) {
+function gesso_nav( $location ) {
   wp_nav_menu(
   array(
 	'theme_location'  => $location,
@@ -38,7 +38,7 @@ function gesso_nav($location) {
 	'link_after'	  => '',
 	'items_wrap'	  => '<nav class="%1$s nav--' . $location . '" role="navigation"><ul class="nav">%3$s</ul></nav>',
 	'depth'		   => 0,
-	'walker'		  => new gesso_walker_nav_menu()
+	'walker'		  => new gesso_walker_nav_menu(),
 	)
   );
 }
@@ -135,7 +135,7 @@ function add_first_and_last($output) {
 	}
 	return $output;
 }
-add_filter('wp_nav_menu', 'add_first_and_last');
+add_filter( 'wp_nav_menu', 'add_first_and_last' );
 
 
 function gesso_header_scripts() {
@@ -170,9 +170,9 @@ add_action('wp_head', 'gesso_styles');
 
 
 function register_gesso_menu() {
-	register_nav_menus(array(
+	register_nav_menus( array(
 		'primary' => __('Primary', 'gesso'),
-		'secondary' => __('Secondary', 'gesso')
+		'secondary' => __('Secondary', 'gesso'),
 	));
 }
 add_action( 'init', 'register_gesso_menu' );
@@ -205,7 +205,7 @@ if ( function_exists('register_sidebar') ) {
 		'before_widget' => '<div id="%1$s" class="widget %2$s">',
 		'after_widget' => '</div>',
 		'before_title' => '<h3 class="widget__title">',
-		'after_title' => '</h3>'
+		'after_title' => '</h3>',
   ) );
 
 	register_sidebar( array(
@@ -215,7 +215,7 @@ if ( function_exists('register_sidebar') ) {
 		'before_widget' => '<div id="%1$s" class="widget %2$s">',
 		'after_widget' => '</div>',
 		'before_title' => '<h3 class="widget__title">',
-		'after_title' => '</h3>'
+		'after_title' => '</h3>',
 	) );
 }
 

--- a/functions.php
+++ b/functions.php
@@ -139,34 +139,41 @@ add_filter( 'wp_nav_menu', 'add_first_and_last' );
 
 
 function gesso_header_scripts() {
-	if ($GLOBALS['pagenow'] != 'wp-login.php' && !is_admin()) {
+	global $wp_styles;
 
-		wp_deregister_script('jquery');
-		wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
-		wp_enqueue_script('jquery');
+	wp_deregister_script('jquery');
+	wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
+	wp_enqueue_script('jquery');
 
-		wp_register_script('modernizr', 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.min.js', array('jquery') ); // Modernizr
-		wp_enqueue_script('modernizr');
+	wp_register_script('modernizr', 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.min.js', array('jquery') ); // Modernizr
+	wp_enqueue_script('modernizr');
 
-		if ( is_singular() && comments_open() ) {
-			wp_enqueue_script( "comment-reply" );
-		}
-
-		wp_register_script('gessomobilemenu', get_template_directory_uri() . '/js/mobile-menu.js', array('jquery','modernizr') ); // Mobile menu
-		wp_enqueue_script('gessomobilemenu');
-
-		wp_register_script('gessoscripts', get_template_directory_uri() . '/js/scripts.js', array('jquery','modernizr') ); // Custom scripts
-		wp_enqueue_script('gessoscripts');
+	if ( is_singular() && comments_open() ) {
+		wp_enqueue_script( "comment-reply" );
 	}
-}
-add_action('init', 'gesso_header_scripts');
 
-// uses echo since wp_register_style() currently has no way to <!--[if gte IE 9]><!--> type conditional comments
-function gesso_styles() {
-	echo '<!--[if gte IE 9]><!--><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/styles.css" media="all"><!--<![endif]-->';
-	echo '<!--[if lt IE 9]><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/no-mq.css" media="all"><![endif]-->';
+	wp_register_script('gessomobilemenu', get_template_directory_uri() . '/js/mobile-menu.js', array('jquery','modernizr') ); // Mobile menu
+	wp_enqueue_script('gessomobilemenu');
+
+	wp_register_script('gessoscripts', get_template_directory_uri() . '/js/scripts.js', array('jquery','modernizr') ); // Custom scripts
+	wp_enqueue_script('gessoscripts');
+
+	wp_enqueue_style( 'style', get_stylesheet_directory_uri() . '/css/styles.css', array(), null, 'all' );
+
+	wp_enqueue_style( 'no-media-queries', get_stylesheet_directory_uri() . '/css/no-mq.css', array( 'style' ), null, 'all' );
+	$wp_styles->add_data( 'no-media-queries', 'conditional', 'lt IE 9' );
 }
-add_action('wp_head', 'gesso_styles');
+add_action( 'wp_enqueue_scripts', 'gesso_header_scripts' );
+
+function gesso_ie_comment_style_css( $html, $handle, $href ) {
+	if( $handle == 'style' ) {
+		// Weird IE conditional jibberish to trick it to ignore the main stylesheet in IE8 and below.
+		$html = '<!--[if gte IE 9]><!-->' . $html . '<!--<![endif]-->';
+	}
+
+	return $html;
+}
+add_filter( 'style_loader_tag', 'gesso_ie_comment_style_css', 10, 3 );
 
 
 function register_gesso_menu() {

--- a/functions.php
+++ b/functions.php
@@ -7,7 +7,7 @@ if ( ! isset( $content_width ) ) {
 
 // Add support for automatic links for feeds.
 add_theme_support( 'automatic-feed-links' );
- 
+
 if (function_exists('add_theme_support')) {
   add_theme_support('post-thumbnails');
   add_image_size('large', 700, '', true); // Large Thumbnail
@@ -20,112 +20,112 @@ if (function_exists('add_theme_support')) {
 function gesso_nav($location) {
   wp_nav_menu(
   array(
-    'theme_location'  => $location,
-    'menu'            => '',
-    'container'       => '',
-    'container_class' => '',
-    'menu_class'      => '',
-    'menu_id'         => '',
-    'echo'            => true,
-    'fallback_cb'     => false,
-    'before'          => '',
-    'after'           => '',
-    'link_before'     => '',
-    'link_after'      => '',
-    'items_wrap'      => '<nav class="%1$s nav--' . $location . '" role="navigation"><ul class="nav">%3$s</ul></nav>',
-    'depth'           => 0,
-    'walker'          => new gesso_walker_nav_menu()
-    )
+	'theme_location'  => $location,
+	'menu'			=> '',
+	'container'	   => '',
+	'container_class' => '',
+	'menu_class'	  => '',
+	'menu_id'		 => '',
+	'echo'			=> true,
+	'fallback_cb'	 => false,
+	'before'		  => '',
+	'after'		   => '',
+	'link_before'	 => '',
+	'link_after'	  => '',
+	'items_wrap'	  => '<nav class="%1$s nav--' . $location . '" role="navigation"><ul class="nav">%3$s</ul></nav>',
+	'depth'		   => 0,
+	'walker'		  => new gesso_walker_nav_menu()
+	)
   );
 }
 
 
 function has_visible_widgets($sidebar_id) {
   if (is_active_sidebar($sidebar_id)) {
-    ob_start();
-    dynamic_sidebar($sidebar_id);
-    $sidebar = ob_get_contents();
-    ob_end_clean();
-    if ($sidebar == "") return false;
+	ob_start();
+	dynamic_sidebar($sidebar_id);
+	$sidebar = ob_get_contents();
+	ob_end_clean();
+	if ($sidebar == "") return false;
   } else {
-    return false;
+	return false;
   }
   return true;
 }
 
 
 class gesso_walker_nav_menu extends Walker_Nav_Menu {
-  
+
   // add classes to ul sub-menus
   function start_lvl( &$output, $depth = 0, $args = array() ) {
-    // depth dependent classes
-    $indent = ( $depth > 0  ? str_repeat( "\t", $depth ) : '' ); // code indent
-    $display_depth = ( $depth + 1); // because it counts the first submenu as 0
-    $classes = array(
-      'sub-menu',
-      ( $display_depth >=2 ? 'sub-sub-menu' : '' ),
-      'menu-depth-' . $display_depth
-      );
-    $class_names = implode( ' ', $classes );
-  
-    // build html
-    $output .= "\n" . $indent . '<ul class="' . $class_names . '">' . "\n";
+	// depth dependent classes
+	$indent = ( $depth > 0  ? str_repeat( "\t", $depth ) : '' ); // code indent
+	$display_depth = ( $depth + 1); // because it counts the first submenu as 0
+	$classes = array(
+	  'sub-menu',
+	  ( $display_depth >=2 ? 'sub-sub-menu' : '' ),
+	  'menu-depth-' . $display_depth
+	  );
+	$class_names = implode( ' ', $classes );
+
+	// build html
+	$output .= "\n" . $indent . '<ul class="' . $class_names . '">' . "\n";
   }
-    
+
   // add main/sub classes to li's and links
    function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
-    global $wp_query;
-    $indent = ( $depth > 0 ? str_repeat( "\t", $depth ) : '' ); // code indent
-  
-    // depth dependent classes
-    $depth_classes = array(
-      ( $depth == 0 ? 'main-menu__item' : 'sub-menu__item' ),
-      ( $depth >=2 ? 'sub-sub-menu__item' : '' )
-    );
-    $depth_class_names = esc_attr( implode( ' ', $depth_classes ) );
-      
-    // passed classes
-    $classes = empty( $item->classes ) ? array() : (array) $item->classes;
-    $class_names = esc_attr( implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) ) );
-    
-    // add active class    
-    if ( is_array($class_names)) { // make sure the menu is an array and not empty or only a single item
-      $class_names .= in_array("current_page_item",$item->classes) ? ' active' : '';
-    }
+	global $wp_query;
+	$indent = ( $depth > 0 ? str_repeat( "\t", $depth ) : '' ); // code indent
 
-    // build html
-    $output .= $indent . '<li class="nav__item ' . $depth_class_names . $class_names .'">';
-  
-    // link attributes
-    $attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
-    $attributes .= ! empty( $item->target )     ? ' target="' . esc_attr( $item->target     ) .'"' : '';
-    $attributes .= ! empty( $item->xfn )        ? ' rel="'    . esc_attr( $item->xfn        ) .'"' : '';
-    $attributes .= ! empty( $item->url )        ? ' href="'   . esc_attr( $item->url        ) .'"' : '';
-    $attributes .= ' class="nav__link ' . ( $depth > 0 ? 'sub-menu__link' : 'main-menu__link' ) . '"';
-  
-    $item_output = sprintf( '%1$s<a%2$s>%3$s%4$s%5$s</a>%6$s',
-      $args->before,
-      $attributes,
-      $args->link_before,
-      apply_filters( 'the_title', $item->title, $item->ID ),
-      $args->link_after,
-      $args->after
-    );
-  
-    // build html
-    $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+	// depth dependent classes
+	$depth_classes = array(
+	  ( $depth == 0 ? 'main-menu__item' : 'sub-menu__item' ),
+	  ( $depth >=2 ? 'sub-sub-menu__item' : '' )
+	);
+	$depth_class_names = esc_attr( implode( ' ', $depth_classes ) );
+
+	// passed classes
+	$classes = empty( $item->classes ) ? array() : (array) $item->classes;
+	$class_names = esc_attr( implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) ) );
+
+	// add active class
+	if ( is_array($class_names)) { // make sure the menu is an array and not empty or only a single item
+	  $class_names .= in_array("current_page_item",$item->classes) ? ' active' : '';
+	}
+
+	// build html
+	$output .= $indent . '<li class="nav__item ' . $depth_class_names . $class_names .'">';
+
+	// link attributes
+	$attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
+	$attributes .= ! empty( $item->target )	 ? ' target="' . esc_attr( $item->target	 ) .'"' : '';
+	$attributes .= ! empty( $item->xfn )		? ' rel="'	. esc_attr( $item->xfn		) .'"' : '';
+	$attributes .= ! empty( $item->url )		? ' href="'   . esc_attr( $item->url		) .'"' : '';
+	$attributes .= ' class="nav__link ' . ( $depth > 0 ? 'sub-menu__link' : 'main-menu__link' ) . '"';
+
+	$item_output = sprintf( '%1$s<a%2$s>%3$s%4$s%5$s</a>%6$s',
+	  $args->before,
+	  $attributes,
+	  $args->link_before,
+	  apply_filters( 'the_title', $item->title, $item->ID ),
+	  $args->link_after,
+	  $args->after
+	);
+
+	// build html
+	$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
   }
 }
 
 // add first/last classes to menus
 function add_first_and_last($output) {
-  // See if the menus have the applied nav__item class, if not the output will remain default 
+  // See if the menus have the applied nav__item class, if not the output will remain default
   // TODO: try to apply this class system to custom menus in widgets or in undefined locations
   if (preg_match('/class="nav__item/', $output)) {
-    if (count($output) > 1) {    
-      $output = preg_replace('/class="nav__item/', 'class="first nav__item', $output, 1);
-      $output = substr_replace($output, 'class="last nav__item', strripos($output, 'class="nav__item'), strlen('class="menu-item'));
-    }
+	if (count($output) > 1) {
+	  $output = preg_replace('/class="nav__item/', 'class="first nav__item', $output, 1);
+	  $output = substr_replace($output, 'class="last nav__item', strripos($output, 'class="nav__item'), strlen('class="menu-item'));
+	}
   }
   return $output;
 }
@@ -134,125 +134,122 @@ add_filter('wp_nav_menu', 'add_first_and_last');
 
 function gesso_header_scripts() {
   if ($GLOBALS['pagenow'] != 'wp-login.php' && !is_admin()) {
-    
-    wp_deregister_script('jquery'); 
-    wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
-    wp_enqueue_script('jquery');  
 
-    wp_register_script('modernizr', 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.min.js', array('jquery') ); // Modernizr
-    wp_enqueue_script('modernizr');  
+	wp_deregister_script('jquery');
+	wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
+	wp_enqueue_script('jquery');
 
-    if ( is_singular() ) wp_enqueue_script( "comment-reply" );
+	wp_register_script('modernizr', 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.min.js', array('jquery') ); // Modernizr
+	wp_enqueue_script('modernizr');
 
-    wp_register_script('gessomobilemenu', get_template_directory_uri() . '/js/mobile-menu.js', array('jquery','modernizr') ); // Mobile menu
-    wp_enqueue_script('gessomobilemenu');  
+	if ( is_singular() ) wp_enqueue_script( "comment-reply" );
 
-    wp_register_script('gessoscripts', get_template_directory_uri() . '/js/scripts.js', array('jquery','modernizr') ); // Custom scripts
-    wp_enqueue_script('gessoscripts');  
+	wp_register_script('gessomobilemenu', get_template_directory_uri() . '/js/mobile-menu.js', array('jquery','modernizr') ); // Mobile menu
+	wp_enqueue_script('gessomobilemenu');
+
+	wp_register_script('gessoscripts', get_template_directory_uri() . '/js/scripts.js', array('jquery','modernizr') ); // Custom scripts
+	wp_enqueue_script('gessoscripts');
   }
 }
+add_action('init', 'gesso_header_scripts');
 
 // uses echo since wp_register_style() currently has no way to <!--[if gte IE 9]><!--> type conditional comments
 function gesso_styles() {
   echo '<!--[if gte IE 9]><!--><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/styles.css" media="all"><!--<![endif]-->';
   echo '<!--[if lt IE 9]><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/no-mq.css" media="all"><![endif]-->';
 }
+add_action('wp_head', 'gesso_styles');
 
 
 function register_gesso_menu() {
-  register_nav_menus(array(  
-    'primary' => __('Primary', 'gesso'),  
-    'secondary' => __('Secondary', 'gesso')
+  register_nav_menus(array(
+	'primary' => __('Primary', 'gesso'),
+	'secondary' => __('Secondary', 'gesso')
   ));
 }
+add_action('init', 'register_gesso_menu');
 
 
 // Add page slug to body class. Credit: Starkers Wordpress Theme
 function add_slug_to_body_class($classes) {
   global $post;
   if (is_home()) {
-    $key = array_search('blog', $classes);
-    if ($key > -1) {
-        unset($classes[$key]);
-    }
+	$key = array_search('blog', $classes);
+	if ($key > -1) {
+		unset($classes[$key]);
+	}
   } elseif (is_page()) {
-    $classes[] = sanitize_html_class($post->post_name);
+	$classes[] = sanitize_html_class($post->post_name);
   } elseif (is_singular()) {
-    $classes[] = sanitize_html_class($post->post_name);
+	$classes[] = sanitize_html_class($post->post_name);
   }
   return $classes;
 }
+add_filter('body_class', 'add_slug_to_body_class');
 
 // Initial Sidebar and Footer Widget Areas
 if (function_exists('register_sidebar')) {
   register_sidebar(array(
-    'name' => __('Widget Area 1', 'gesso'),
-    'description' => __('Widget Area 1', 'gesso'),
-    'id' => 'widget-area-1',
-    'before_widget' => '<div id="%1$s" class="widget %2$s">',
-    'after_widget' => '</div>',
-    'before_title' => '<h3 class="widget__title">',
-    'after_title' => '</h3>'
+	'name' => __('Widget Area 1', 'gesso'),
+	'description' => __('Widget Area 1', 'gesso'),
+	'id' => 'widget-area-1',
+	'before_widget' => '<div id="%1$s" class="widget %2$s">',
+	'after_widget' => '</div>',
+	'before_title' => '<h3 class="widget__title">',
+	'after_title' => '</h3>'
   ));
-  
+
   register_sidebar(array(
-    'name' => __('Footer Widgets', 'gesso'),
-    'description' => __('Footer Widgets', 'gesso'),
-    'id' => 'footer-widgets',
-    'before_widget' => '<div id="%1$s" class="widget %2$s">',
-    'after_widget' => '</div>',
-    'before_title' => '<h3 class="widget__title">',
-    'after_title' => '</h3>'
+	'name' => __('Footer Widgets', 'gesso'),
+	'description' => __('Footer Widgets', 'gesso'),
+	'id' => 'footer-widgets',
+	'before_widget' => '<div id="%1$s" class="widget %2$s">',
+	'after_widget' => '</div>',
+	'before_title' => '<h3 class="widget__title">',
+	'after_title' => '</h3>'
   ));
 }
 
 function gesso_pagination() {
   global $wp_query;
   $big = 999999999;
-  echo paginate_links(array(
-    'base' => str_replace($big, '%#%', get_pagenum_link($big)),
-    'format' => '?paged=%#%',
-    'current' => max(1, get_query_var('paged')),
-    'total' => $wp_query->max_num_pages
-  ));
+  echo paginate_links( array(
+	'base' => str_replace( $big, '%#%', get_pagenum_link( $big ) ),
+	'format' => '?paged=%#%',
+	'current' => max( 1, get_query_var('paged') ),
+	'total' => $wp_query->max_num_pages,
+  ) );
 }
+add_action('init', 'gesso_pagination');
 
 //Adds proper markup to pages content
 function gesso_link_pages() {
   $gesso_links = array(
-      'before'      => '<nav class="page-links" role="navigation"><h2 class="page-links-title element-invisible">' . __( 'Pages:', 'gesso' ) . '</h2>',
-      'after'       => '</nav>',
-      'link_before' => '<span class="pager__item">',
-      'link_after'  => '</span>',
-    );
+	  'before'	  => '<nav class="page-links" role="navigation"><h2 class="page-links-title element-invisible">' . __( 'Pages:', 'gesso' ) . '</h2>',
+	  'after'	   => '</nav>',
+	  'link_before' => '<span class="pager__item">',
+	  'link_after'  => '</span>',
+	);
   wp_link_pages($gesso_links);
 }
 
 
- // Remove thumbnail dimensions  
+ // Remove thumbnail dimensions
 function remove_thumbnail_dimensions( $html ) {
   $html = preg_replace('/(width|height)=\"\d*\"\s/', "", $html);
   return $html;
 }
+add_filter('post_thumbnail_html', 'remove_thumbnail_dimensions', 10); // Remove width and height attributes from thumbnails
+add_filter('image_send_to_editor', 'remove_thumbnail_dimensions', 10); // Remove width and height attributes from post images
 
 // Adds site name to title tag
 add_theme_support( 'title-tag' );
 
-// Allowing styles for post editor to match how it will actually be visually represented 
+// Allowing styles for post editor to match how it will actually be visually represented
 function gesso_add_editor_styles() {
-    add_editor_style( 'css/custom-editor-style.css' );
+	add_editor_style( 'css/custom-editor-style.css' );
 }
+add_action( 'admin_init', 'gesso_add_editor_styles' );
 
 // Adding theme support for HTML5
 add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption' ) );
-
-
-add_action('init', 'gesso_header_scripts');  
-add_action('wp_head', 'gesso_styles');
-add_action('init', 'gesso_pagination'); 
-add_action('init', 'register_gesso_menu');  
-
-add_filter('body_class', 'add_slug_to_body_class');  
-add_filter('post_thumbnail_html', 'remove_thumbnail_dimensions', 10); // Remove width and height dynamic attributes to thumbnails
-add_filter('image_send_to_editor', 'remove_thumbnail_dimensions', 10); // Remove width and height dynamic attributes to post images
-add_action( 'admin_init', 'gesso_add_editor_styles' );

--- a/functions.php
+++ b/functions.php
@@ -2,18 +2,22 @@
 
 // Setting main content width - update to match the width of your site's main content area.
 if ( ! isset( $content_width ) ) {
-  $content_width = 760;
+	$content_width = 760;
 }
 
-// Add support for automatic links for feeds.
-add_theme_support( 'automatic-feed-links' );
+if ( function_exists('add_theme_support') ) {
+    // Adding theme support for HTML5
+    add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption' ) );
+	// Adds site name to title tag
+	add_theme_support( 'title-tag' );
+	// Add support for automatic links for feeds.
+	add_theme_support( 'automatic-feed-links' );
 
-if (function_exists('add_theme_support')) {
-  add_theme_support('post-thumbnails');
-  add_image_size('large', 700, '', true); // Large Thumbnail
-  add_image_size('medium', 250, '', true); // Medium Thumbnail
-  add_image_size('small', 120, '', true); // Small Thumbnail
-  add_image_size('custom-size', 700, 200, true); // Custom Thumbnail Size call using the_post_thumbnail('custom-size');
+	add_theme_support( 'post-thumbnails' );
+	add_image_size( 'large', 700, '', true ); // Large Thumbnail
+	add_image_size( 'medium', 250, '', true ); // Medium Thumbnail
+	add_image_size( 'small', 120, '', true ); // Small Thumbnail
+	add_image_size( 'custom-size', 700, 200, true ); // Custom Thumbnail Size call using the_post_thumbnail('custom-size');
 }
 
 
@@ -40,13 +44,15 @@ function gesso_nav($location) {
 }
 
 
-function has_visible_widgets($sidebar_id) {
-  if (is_active_sidebar($sidebar_id)) {
+function has_visible_widgets( $sidebar_id ) {
+  if ( is_active_sidebar( $sidebar_id ) ) {
 	ob_start();
-	dynamic_sidebar($sidebar_id);
+	dynamic_sidebar( $sidebar_id );
 	$sidebar = ob_get_contents();
 	ob_end_clean();
-	if ($sidebar == "") return false;
+	if ( $sidebar == "" ) {
+		return false;
+	}
   } else {
 	return false;
   }
@@ -56,200 +62,198 @@ function has_visible_widgets($sidebar_id) {
 
 class gesso_walker_nav_menu extends Walker_Nav_Menu {
 
-  // add classes to ul sub-menus
-  function start_lvl( &$output, $depth = 0, $args = array() ) {
-	// depth dependent classes
-	$indent = ( $depth > 0  ? str_repeat( "\t", $depth ) : '' ); // code indent
-	$display_depth = ( $depth + 1); // because it counts the first submenu as 0
-	$classes = array(
-	  'sub-menu',
-	  ( $display_depth >=2 ? 'sub-sub-menu' : '' ),
-	  'menu-depth-' . $display_depth
-	  );
-	$class_names = implode( ' ', $classes );
+	// add classes to ul sub-menus
+	function start_lvl( &$output, $depth = 0, $args = array() ) {
+		// depth dependent classes
+		$indent = ( $depth > 0  ? str_repeat( "\t", $depth ) : '' ); // code indent
+		$display_depth = ( $depth + 1); // because it counts the first submenu as 0
+		$classes = array(
+		  'sub-menu',
+		  ( $display_depth >=2 ? 'sub-sub-menu' : '' ),
+		  'menu-depth-' . $display_depth
+		);
+		$class_names = implode( ' ', $classes );
 
-	// build html
-	$output .= "\n" . $indent . '<ul class="' . $class_names . '">' . "\n";
-  }
-
-  // add main/sub classes to li's and links
-   function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
-	global $wp_query;
-	$indent = ( $depth > 0 ? str_repeat( "\t", $depth ) : '' ); // code indent
-
-	// depth dependent classes
-	$depth_classes = array(
-	  ( $depth == 0 ? 'main-menu__item' : 'sub-menu__item' ),
-	  ( $depth >=2 ? 'sub-sub-menu__item' : '' )
-	);
-	$depth_class_names = esc_attr( implode( ' ', $depth_classes ) );
-
-	// passed classes
-	$classes = empty( $item->classes ) ? array() : (array) $item->classes;
-	$class_names = esc_attr( implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) ) );
-
-	// add active class
-	if ( is_array($class_names)) { // make sure the menu is an array and not empty or only a single item
-	  $class_names .= in_array("current_page_item",$item->classes) ? ' active' : '';
+		// build html
+		$output .= "\n" . $indent . '<ul class="' . $class_names . '">' . "\n";
 	}
 
-	// build html
-	$output .= $indent . '<li class="nav__item ' . $depth_class_names . $class_names .'">';
+	// add main/sub classes to li's and links
+	function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
+		global $wp_query;
+		$indent = ( $depth > 0 ? str_repeat( "\t", $depth ) : '' ); // code indent
 
-	// link attributes
-	$attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
-	$attributes .= ! empty( $item->target )	 ? ' target="' . esc_attr( $item->target	 ) .'"' : '';
-	$attributes .= ! empty( $item->xfn )		? ' rel="'	. esc_attr( $item->xfn		) .'"' : '';
-	$attributes .= ! empty( $item->url )		? ' href="'   . esc_attr( $item->url		) .'"' : '';
-	$attributes .= ' class="nav__link ' . ( $depth > 0 ? 'sub-menu__link' : 'main-menu__link' ) . '"';
+		// depth dependent classes
+		$depth_classes = array(
+			( $depth == 0 ? 'main-menu__item' : 'sub-menu__item' ),
+			( $depth >=2 ? 'sub-sub-menu__item' : '' )
+		);
+		$depth_class_names = esc_attr( implode( ' ', $depth_classes ) );
 
-	$item_output = sprintf( '%1$s<a%2$s>%3$s%4$s%5$s</a>%6$s',
-	  $args->before,
-	  $attributes,
-	  $args->link_before,
-	  apply_filters( 'the_title', $item->title, $item->ID ),
-	  $args->link_after,
-	  $args->after
-	);
+		// passed classes
+		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
+		$class_names = esc_attr( implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item ) ) );
 
-	// build html
-	$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+		// add active class
+		if ( is_array($class_names) ) { // make sure the menu is an array and not empty or only a single item
+			$class_names .= in_array("current_page_item",$item->classes) ? ' active' : '';
+		}
+
+		// build html
+		$output .= $indent . '<li class="nav__item ' . $depth_class_names . $class_names .'">';
+
+		// link attributes
+		$attributes  = ! empty( $item->attr_title ) ? ' title="'  . esc_attr( $item->attr_title ) .'"' : '';
+		$attributes .= ! empty( $item->target )	 ? ' target="' . esc_attr( $item->target	 ) .'"' : '';
+		$attributes .= ! empty( $item->xfn )		? ' rel="'	. esc_attr( $item->xfn		) .'"' : '';
+		$attributes .= ! empty( $item->url )		? ' href="'   . esc_attr( $item->url		) .'"' : '';
+		$attributes .= ' class="nav__link ' . ( $depth > 0 ? 'sub-menu__link' : 'main-menu__link' ) . '"';
+
+		$item_output = sprintf( '%1$s<a%2$s>%3$s%4$s%5$s</a>%6$s',
+			$args->before,
+			$attributes,
+			$args->link_before,
+			apply_filters( 'the_title', $item->title, $item->ID ),
+			$args->link_after,
+			$args->after
+		);
+
+		// build html
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
   }
 }
 
 // add first/last classes to menus
 function add_first_and_last($output) {
-  // See if the menus have the applied nav__item class, if not the output will remain default
-  // TODO: try to apply this class system to custom menus in widgets or in undefined locations
-  if (preg_match('/class="nav__item/', $output)) {
-	if (count($output) > 1) {
-	  $output = preg_replace('/class="nav__item/', 'class="first nav__item', $output, 1);
-	  $output = substr_replace($output, 'class="last nav__item', strripos($output, 'class="nav__item'), strlen('class="menu-item'));
+	// See if the menus have the applied nav__item class, if not the output will remain default
+	// TODO: try to apply this class system to custom menus in widgets or in undefined locations
+	if (preg_match('/class="nav__item/', $output)) {
+		if (count($output) > 1) {
+			$output = preg_replace('/class="nav__item/', 'class="first nav__item', $output, 1);
+			$output = substr_replace($output, 'class="last nav__item', strripos($output, 'class="nav__item'), strlen('class="menu-item'));
+		}
 	}
-  }
-  return $output;
+	return $output;
 }
 add_filter('wp_nav_menu', 'add_first_and_last');
 
 
 function gesso_header_scripts() {
-  if ($GLOBALS['pagenow'] != 'wp-login.php' && !is_admin()) {
+	if ($GLOBALS['pagenow'] != 'wp-login.php' && !is_admin()) {
 
-	wp_deregister_script('jquery');
-	wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
-	wp_enqueue_script('jquery');
+		wp_deregister_script('jquery');
+		wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
+		wp_enqueue_script('jquery');
 
-	wp_register_script('modernizr', 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.min.js', array('jquery') ); // Modernizr
-	wp_enqueue_script('modernizr');
+		wp_register_script('modernizr', 'http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.7.1/modernizr.min.js', array('jquery') ); // Modernizr
+		wp_enqueue_script('modernizr');
 
-	if ( is_singular() ) wp_enqueue_script( "comment-reply" );
+		if ( is_singular() && comments_open() ) {
+			wp_enqueue_script( "comment-reply" );
+		}
 
-	wp_register_script('gessomobilemenu', get_template_directory_uri() . '/js/mobile-menu.js', array('jquery','modernizr') ); // Mobile menu
-	wp_enqueue_script('gessomobilemenu');
+		wp_register_script('gessomobilemenu', get_template_directory_uri() . '/js/mobile-menu.js', array('jquery','modernizr') ); // Mobile menu
+		wp_enqueue_script('gessomobilemenu');
 
-	wp_register_script('gessoscripts', get_template_directory_uri() . '/js/scripts.js', array('jquery','modernizr') ); // Custom scripts
-	wp_enqueue_script('gessoscripts');
-  }
+		wp_register_script('gessoscripts', get_template_directory_uri() . '/js/scripts.js', array('jquery','modernizr') ); // Custom scripts
+		wp_enqueue_script('gessoscripts');
+	}
 }
 add_action('init', 'gesso_header_scripts');
 
 // uses echo since wp_register_style() currently has no way to <!--[if gte IE 9]><!--> type conditional comments
 function gesso_styles() {
-  echo '<!--[if gte IE 9]><!--><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/styles.css" media="all"><!--<![endif]-->';
-  echo '<!--[if lt IE 9]><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/no-mq.css" media="all"><![endif]-->';
+	echo '<!--[if gte IE 9]><!--><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/styles.css" media="all"><!--<![endif]-->';
+	echo '<!--[if lt IE 9]><link rel="stylesheet" href="' . get_template_directory_uri() . '/css/no-mq.css" media="all"><![endif]-->';
 }
 add_action('wp_head', 'gesso_styles');
 
 
 function register_gesso_menu() {
-  register_nav_menus(array(
-	'primary' => __('Primary', 'gesso'),
-	'secondary' => __('Secondary', 'gesso')
-  ));
+	register_nav_menus(array(
+		'primary' => __('Primary', 'gesso'),
+		'secondary' => __('Secondary', 'gesso')
+	));
 }
-add_action('init', 'register_gesso_menu');
+add_action( 'init', 'register_gesso_menu' );
 
 
 // Add page slug to body class. Credit: Starkers Wordpress Theme
-function add_slug_to_body_class($classes) {
-  global $post;
-  if (is_home()) {
-	$key = array_search('blog', $classes);
-	if ($key > -1) {
-		unset($classes[$key]);
+function add_slug_to_body_class( $classes ) {
+	global $post;
+	if (is_home()) {
+		$key = array_search( 'blog', $classes );
+		if ( $key > -1 ) {
+			unset( $classes[ $key ] );
+		}
+	} elseif ( is_page() ) {
+		$classes[] = sanitize_html_class( $post->post_name );
+	} elseif ( is_singular() ) {
+		$classes[] = sanitize_html_class( $post->post_name );
 	}
-  } elseif (is_page()) {
-	$classes[] = sanitize_html_class($post->post_name);
-  } elseif (is_singular()) {
-	$classes[] = sanitize_html_class($post->post_name);
-  }
+
   return $classes;
 }
-add_filter('body_class', 'add_slug_to_body_class');
+add_filter( 'body_class', 'add_slug_to_body_class' );
 
 // Initial Sidebar and Footer Widget Areas
-if (function_exists('register_sidebar')) {
-  register_sidebar(array(
-	'name' => __('Widget Area 1', 'gesso'),
-	'description' => __('Widget Area 1', 'gesso'),
-	'id' => 'widget-area-1',
-	'before_widget' => '<div id="%1$s" class="widget %2$s">',
-	'after_widget' => '</div>',
-	'before_title' => '<h3 class="widget__title">',
-	'after_title' => '</h3>'
-  ));
+if ( function_exists('register_sidebar') ) {
+	register_sidebar( array(
+		'name' => __('Widget Area 1', 'gesso'),
+		'description' => __('Widget Area 1', 'gesso'),
+		'id' => 'widget-area-1',
+		'before_widget' => '<div id="%1$s" class="widget %2$s">',
+		'after_widget' => '</div>',
+		'before_title' => '<h3 class="widget__title">',
+		'after_title' => '</h3>'
+  ) );
 
-  register_sidebar(array(
-	'name' => __('Footer Widgets', 'gesso'),
-	'description' => __('Footer Widgets', 'gesso'),
-	'id' => 'footer-widgets',
-	'before_widget' => '<div id="%1$s" class="widget %2$s">',
-	'after_widget' => '</div>',
-	'before_title' => '<h3 class="widget__title">',
-	'after_title' => '</h3>'
-  ));
+	register_sidebar( array(
+		'name' => __('Footer Widgets', 'gesso'),
+		'description' => __('Footer Widgets', 'gesso'),
+		'id' => 'footer-widgets',
+		'before_widget' => '<div id="%1$s" class="widget %2$s">',
+		'after_widget' => '</div>',
+		'before_title' => '<h3 class="widget__title">',
+		'after_title' => '</h3>'
+	) );
 }
 
 function gesso_pagination() {
-  global $wp_query;
-  $big = 999999999;
-  echo paginate_links( array(
-	'base' => str_replace( $big, '%#%', get_pagenum_link( $big ) ),
-	'format' => '?paged=%#%',
-	'current' => max( 1, get_query_var('paged') ),
-	'total' => $wp_query->max_num_pages,
-  ) );
+	global $wp_query;
+	$big = 999999999;
+	echo paginate_links( array(
+		'base' => str_replace( $big, '%#%', get_pagenum_link( $big ) ),
+		'format' => '?paged=%#%',
+		'current' => max( 1, get_query_var('paged') ),
+		'total' => $wp_query->max_num_pages,
+	) );
 }
 add_action('init', 'gesso_pagination');
 
 //Adds proper markup to pages content
 function gesso_link_pages() {
-  $gesso_links = array(
-	  'before'	  => '<nav class="page-links" role="navigation"><h2 class="page-links-title element-invisible">' . __( 'Pages:', 'gesso' ) . '</h2>',
-	  'after'	   => '</nav>',
-	  'link_before' => '<span class="pager__item">',
-	  'link_after'  => '</span>',
+	$gesso_links = array(
+		'before'	  => '<nav class="page-links" role="navigation"><h2 class="page-links-title element-invisible">' . __( 'Pages:', 'gesso' ) . '</h2>',
+		'after'	   => '</nav>',
+		'link_before' => '<span class="pager__item">',
+		'link_after'  => '</span>',
 	);
-  wp_link_pages($gesso_links);
+	wp_link_pages( $gesso_links );
 }
 
 
  // Remove thumbnail dimensions
 function remove_thumbnail_dimensions( $html ) {
-  $html = preg_replace('/(width|height)=\"\d*\"\s/', "", $html);
-  return $html;
-}
-add_filter('post_thumbnail_html', 'remove_thumbnail_dimensions', 10); // Remove width and height attributes from thumbnails
-add_filter('image_send_to_editor', 'remove_thumbnail_dimensions', 10); // Remove width and height attributes from post images
+	$html = preg_replace( '/(width|height)=\"\d*\"\s/', '', $html );
 
-// Adds site name to title tag
-add_theme_support( 'title-tag' );
+	return $html;
+}
+add_filter( 'post_thumbnail_html', 'remove_thumbnail_dimensions', 10 ); // Remove width and height attributes from thumbnails
+add_filter( 'image_send_to_editor', 'remove_thumbnail_dimensions', 10 ); // Remove width and height attributes from post images
 
 // Allowing styles for post editor to match how it will actually be visually represented
 function gesso_add_editor_styles() {
 	add_editor_style( 'css/custom-editor-style.css' );
 }
 add_action( 'admin_init', 'gesso_add_editor_styles' );
-
-// Adding theme support for HTML5
-add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption' ) );

--- a/style.css
+++ b/style.css
@@ -2,17 +2,17 @@
 Theme Name: Gesso
 Theme URI: http://forumone.com
 Description: Gesso Starter Theme
-Version: 0.1
+Version: 0.1.1
 Author: Forum One
 Author URI: http://forumone.com
 Tags:  responsive-layout, right-sidebar, two-columns, accessibility-ready
-License: 
-License URI: 
+License:
+License URI:
 */
 
 
-/* 
-Notes: 
-This file is not intended to be used for CSS.  
+/*
+Notes:
+This file is not intended to be used for CSS.
 This theme uses Sass, which outputs the final CSS files into the /css/ directory.
 */


### PR DESCRIPTION
With the CSS files printed directly to the `<head>` you lose the ability to dequeue and order CSS dependencies. A good use case would be to make sure Google Fonts are loaded first before the main stylesheet. 

This pull request fixes that while retaining the IE conditional comments ensuring the media queried version of styles doesn't get sent to IE8 and below. 

Also did a little cleaning up of the `functions.php` to conform to WordPress coding standards. 