### PR TITLE
Using post.class to output all the default WP classes

### DIFF
--- a/views/single.twig
+++ b/views/single.twig
@@ -3,7 +3,7 @@
 {% block content %}
 		<h1>Using Single.Twig</h1>
 		<div class="content-wrapper">
-			<article class="post-type-{{post.post_type}}" id="post-{{post.ID}}">
+			<article class="{{ post.class }}" id="post-{{post.ID}}">
 				<section class="article-content">
 					<h2 class="article-title">{{post.title}}</h2>
 					<div class="article-body">


### PR DESCRIPTION
Using twig's `post.class` in favor of the default WordPress call of `<?php post_class(); ?>`. This method is preferably used because WordPress dynamically outputs some additional classes into the `<article>` tag which can be useful. Also some plugins and themes uses the [`post_class`](https://developer.wordpress.org/reference/hooks/post_class/) filter to add or modify this classes to be outputted on the `<?php post_class(); ?>` call. 

As reference see it's usage in the master branch https://github.com/forumone/gesso-theme-wordpress/blob/master/single.php#L11

Example on Timber docs http://timber.github.io/timber/#single-product