### PR TITLE
Fixed #8 - Add support for post specific template

### DIFF
--- a/single.php
+++ b/single.php
@@ -16,5 +16,5 @@ $context['comment_form'] = TimberHelper::get_comment_form();
 if ( post_password_required( $post->ID ) ) {
 	Timber::render( 'single-password.twig', $context );
 } else {
-	Timber::render( array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ), $context );
+	Timber::render( array( 'single-' . $post->post_type . '-' . $post->slug . '.twig', 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ), $context );
 }


### PR DESCRIPTION
single-{post-type}-{slug}.php is now supported, and first in the template hierarchy: https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post