### PR TITLE
Gesso-WP Helper functions included into starter theme code

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,15 @@
 <?php
 
+/*------------------------------------------------------------------*
+ * Helper Functions
+/*------------------------------------------------------------------*/
+
+require_once( get_template_directory() . '/inc/helpers.php' );
+
+/*------------------------------------------------------------------*
+ * Core Theme Features
+/*------------------------------------------------------------------*/
+
 // Setting main content width - update to match the width of your site's main content area.
 if ( ! isset( $content_width ) ) {
   $content_width = 840;
@@ -42,8 +52,8 @@ function gesso_nav( $location ) {
       'items_wrap'    => '<nav class="%1$s nav--' . $location . '" role="navigation"><ul class="nav">%3$s</ul></nav>',
       'depth'       => 0,
       'walker'      => new gesso_walker_nav_menu(),
-    )
-  );
+      )
+    );
 }
 
 
@@ -74,7 +84,7 @@ class gesso_walker_nav_menu extends Walker_Nav_Menu {
       'sub-menu',
       ( $display_depth >=2 ? 'sub-sub-menu' : '' ),
       'menu-depth-' . $display_depth
-    );
+      );
     $class_names = implode( ' ', $classes );
 
     // build html
@@ -90,7 +100,7 @@ class gesso_walker_nav_menu extends Walker_Nav_Menu {
     $depth_classes = array(
       ( $depth == 0 ? 'main-menu__item' : 'sub-menu__item' ),
       ( $depth >=2 ? 'sub-sub-menu__item' : '' )
-    );
+      );
     $depth_class_names = esc_attr( implode( ' ', $depth_classes ) );
 
     // passed classes
@@ -119,7 +129,7 @@ class gesso_walker_nav_menu extends Walker_Nav_Menu {
       apply_filters( 'the_title', $item->title, $item->ID ),
       $args->link_after,
       $args->after
-    );
+      );
 
     // build html
     $output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
@@ -170,7 +180,7 @@ function register_gesso_menu() {
   register_nav_menus( array(
     'primary' => __('Primary', 'gesso'),
     'secondary' => __('Secondary', 'gesso'),
-  ));
+    ));
 }
 add_action( 'init', 'register_gesso_menu' );
 
@@ -204,7 +214,7 @@ function gesso_widgets_init() {
     'after_widget' => '</div>',
     'before_title' => '<h3 class="widget__title">',
     'after_title' => '</h3>'
-  ));
+    ));
 
   register_sidebar(array(
     'name' => __('Footer Widgets', 'gesso'),
@@ -214,7 +224,7 @@ function gesso_widgets_init() {
     'after_widget' => '</div>',
     'before_title' => '<h3 class="widget__title">',
     'after_title' => '</h3>'
-  ));
+    ));
 }
 
 function gesso_pagination() {
@@ -225,7 +235,7 @@ function gesso_pagination() {
     'format' => '?paged=%#%',
     'current' => max( 1, get_query_var('paged') ),
     'total' => $wp_query->max_num_pages,
-  ) );
+    ) );
 }
 add_action('init', 'gesso_pagination');
 
@@ -236,7 +246,7 @@ function gesso_link_pages() {
     'after'     => '</ul></nav>',
     'link_before' => '<li class="pager__item>',
     'link_after'  => '</li>',
-  );
+    );
   wp_link_pages( $gesso_links );
 }
 

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1,0 +1,162 @@
+<?php
+
+/*------------------------------------------------------------------*
+ * Useful functions to speed up development. 
+ * DRY principle: https://en.wikipedia.org/wiki/Don't_repeat_yourself
+/*------------------------------------------------------------------*/
+
+/**
+ * Adds a post_type_label filter for twig
+ * @param object $twig
+ * @return object
+ */
+function f1__add_post_type_label_filter( $twig ) {
+	$twig->addExtension( new Twig_Extension_StringLoader() );
+	$twig->addFilter( new Twig_SimpleFilter( 'post_type_label', 'f1__get_post_type_label' ) );
+	return $twig;
+}
+add_filter( 'timber/twig', 'f1__add_post_type_label_filter' );
+
+
+/**
+ * Returns a Timber\Post object of posts.
+ * @param array $collection
+ * @return array/null
+ */
+function f1__get_posts( $collection = null ) {
+	if ( !is_array( $collection ) )
+		return null;
+	
+	$result = Timber::get_posts(
+		array(
+			'post_type'   => 'any',
+			'post__in' => $collection,
+			'orderby' => 'post__in'
+			)
+		);
+	return $result;
+}
+
+
+/**
+ * Returns a Timber\Post object of posts related by single taxonomy.
+ * @param string $post_type
+ * @param string $taxonomy
+ * @param array $terms
+ * @param int $qty
+ * @param int $exclude
+ * @return array
+ */
+function f1__get_posts_by_tax( $post_type = 'post', $taxonomy = null, $terms = null, $qty = null, $exclude = null ) {
+	if ( !is_array( $terms ) )
+		return null;
+	$result = Timber::get_posts(
+		array(
+			'post_type'   => $post_type,
+			'tax_query' => array(
+				array(
+					'taxonomy' => $taxonomy,
+					'field'    => 'term_id',
+					'terms'    => $terms
+					)
+				),
+			'posts_per_page' => $qty,
+			'post__not_in' => array( $exclude )
+			)
+		);
+	return $result;
+}
+
+
+/**
+ * Returns a Timber\Post object of posts including pagination.
+ * @param string $post_type
+ * @return array
+ */
+function f1__get_posts_with_pagination( $post_type = 'post' ) {
+	global $paged;
+	if ( !isset( $paged ) || !$paged ) {
+		$paged = 1;
+	}
+	$args = array(
+		'post_type' => $post_type,
+		'paged' => $paged
+		);
+	return new Timber\PostQuery( $args );
+}
+
+
+/**
+ * Returns a Timber\Image object for a given media ID.
+ * @param int $id
+ * @return array/null
+ */
+function f1__get_image( $id ) {
+	if ( strlen( $id ) ) {
+		return new TimberImage( $id );
+	} else {
+		return null;
+	}
+}
+
+
+/**
+ * Returns a given ammount of Timber\Post objects.
+ * @param mixed $post_type
+ * @param int $qty
+ * @return array
+ */
+function f1__get_posts_block( $post_type, $qty ) {
+	return Timber::get_posts(
+		array(
+			'post_type' => $post_type,
+			'posts_per_page' => $qty,
+			)
+		);
+}
+
+
+/**
+ * Returns a Timber\TimberFunctionWrapper widget sidebar.
+ * @param int $id
+ * @return array
+ */
+function f1__get_sidebar( $id ) {
+	return Timber::get_widgets( $id );
+}
+
+
+/**
+ * Check the post type and return a label for it.
+ * @param string $post_type
+ * @return string
+ */
+function f1__get_post_type_label( $post_type ) {
+	$obj = get_post_type_object( $post_type );
+	return apply_filters( 'f1/get_post_type_label' , $obj->labels->singular_name, $obj );
+}
+
+
+/**
+ * Adds a post_type_label property to each post object inside an array of posts objects.
+ * @param object $posts
+ * @return object
+ */
+function f1__add_post_type_labels( $posts ) {
+	// Add a post type label to each post.
+	for( $i = 0, $size = count( $posts ); $i < $size; ++$i ) {
+		$posts[$i]->post_type_label = f1__get_post_type_label( $posts[$i]->post_type );
+	}
+	return $posts;
+}
+
+
+/**
+ * Returns a WordPress menu.
+ * @param int|string|WP_Term $menu
+ * @return object
+ */
+function f1__get_menu( $menu ) {
+	return TimberHelper::function_wrapper( 'wp_nav_menu', array( 'menu' => $menu ) );
+}
+


### PR DESCRIPTION
@coreylafferty The helper functions from [this package](https://github.com/forumone/Gesso-WP-Helper) are now wrapped into the template code itself. As mentioned earlier they are optional to use if the developer seems the case for them. And doesn't affect or changes any starter setup currently defined on [functions.php](https://github.com/forumone/gesso-wp/blob/helper-functions/functions.php) file.

I'll try later to put some documentation and list each function with example cases in the [wiki here at this repo](https://github.com/forumone/gesso-wp/wiki).

After merging this branch to master, we are good to delete [this repo](https://github.com/forumone/Gesso-WP-Helper), and ideally set a redirect to [this file, or folder](https://github.com/forumone/gesso-wp/blob/helper-functions/inc/helpers.php), once in master, for those following the previous link.