### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -48,7 +48,7 @@ function has_visible_widgets( $sidebar_id ) {
   return true;
 }
 
-function gesso_header_scripts() {
+function gesso_scripts() {
 
   wp_deregister_script('jquery');
   wp_register_script('jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery
@@ -70,7 +70,7 @@ function gesso_header_scripts() {
   wp_enqueue_style( 'style', get_stylesheet_directory_uri() . '/css/styles.css', array(), null, 'all' );
 
 }
-add_action( 'wp_enqueue_scripts', 'gesso_header_scripts' );
+add_action( 'wp_enqueue_scripts', 'gesso_scripts' );
 
 function register_gesso_menu() {
   register_nav_menus( array(


### PR DESCRIPTION
Calling this function "gesso_scripts" instead of "gesso_header_scripts" I think makes better justice. This function wraps other WordPress API functions to include CSS and JS files. 

CSS files are enqueued by [wp_enqueue_style()](https://developer.wordpress.org/reference/functions/wp_enqueue_style/) and will output always between `<head></head>`. 

But, JS files are enqueued by [wp_enqueue_script()](https://developer.wordpress.org/reference/functions/wp_enqueue_script/) and this one has a optional `$in_footer` parameter which is used to output the JS file in the footer just before `</body>`. Generally JS scripts will use this parameter to go to the footer instead of the header to avoid render-blocking JavaScript issues and have a better page load performance.