### PR TITLE
We almost never use post-formats

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -177,7 +177,6 @@ Timber::$dirname = array('templates');
 class StarterSite extends TimberSite {
 
   function __construct() {
-    add_theme_support( 'post-formats' );
     add_theme_support( 'post-thumbnails' );
     add_theme_support( 'menus' );
     add_filter( 'timber/context', array( $this, 'add_to_context' ) );

--- a/functions.php
+++ b/functions.php
@@ -177,6 +177,7 @@ Timber::$dirname = array('templates');
 class StarterSite extends TimberSite {
 
   function __construct() {
+    // add_theme_support( 'post-formats' ); // uncomment to enable post formats
     add_theme_support( 'post-thumbnails' );
     add_theme_support( 'menus' );
     add_filter( 'timber/context', array( $this, 'add_to_context' ) );


### PR DESCRIPTION
So far I haven't seen a use case for ['post-formats'](https://codex.wordpress.org/Post_Formats) in our projects. We find ourselves always needing to remove this line to avoid unnecessary clutter having an empty "Post Formats" metabox widget in the Posts edit backend.

Maybe it does makes sense to remove this line from the base Gesso-WP theme? If in a future project we find a use case for them, we can always put it back for that project specifically.