### PR TITLE
Fixes GitHub link to Drupal Gesso repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to share the same markup.
 For more information, view the
 [Gesso WordPress GitHub repo](https://github.com/forumone/gesso-wp).
 To submit bug reports or feature requests, visit the
-[Gesso WordPress issue queue](https://github.com/forumone/gesso-wp/issues).  Also available for [Drupal](https://github/forumone/gesso).
+[Gesso WordPress issue queue](https://github.com/forumone/gesso-wp/issues).  Also available for [Drupal](https://github.com/forumone/gesso).
 
 ### Global Prerequisites
 The following packages need to be installed on your system in order to use


### PR DESCRIPTION
Trivial update that fixes the link to the Drupal version of the Gesso theme repo.