### PR TITLE
Use front-page.twig when is_front_page() true

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ $context = Timber::get_context();
 $context['posts'] = Timber::get_posts();
 $context['pagination'] = Timber::get_pagination();
 $templates = array( 'index.twig' );
-if ( is_home() ) {
+if ( is_front_page() ) {
 	array_unshift( $templates, 'front-page.twig' );
 }
 Timber::render( $templates, $context );


### PR DESCRIPTION
Here we should use `is_front_page()` instead of `is_home()`.

https://www.binarymoon.co.uk/2018/03/wordpress-the-difference-between-is_home-and-is_front_page/