### PR TITLE
coding standards for IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ js/dist/*.map
 dependencyGraph.json
 .vscode
 .idea
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,46 @@
+{
+	"name": "forumone/gesso-wp",
+	"description": "The Forum One Gesso WordPress starter theme.",
+	"type": "wordpress-theme",
+	"homepage": "https://github.com/forumone/gesso-wp",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "Forum One",
+			"email": "wordpress@forumone.com",
+			"homepage": "https://www.forumone.com/"
+		}
+	],
+	"config": {
+		"platform": {
+			"php": "7.3"
+		},
+		"optimize-autoloader": true
+	},
+	"require-dev": {
+		"php": ">=7.3.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+		"squizlabs/php_codesniffer": "^3.5",
+		"wp-coding-standards/wpcs": "^2.3",
+		"phpcompatibility/php-compatibility": "^9.3",
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"roave/security-advisories": "dev-master",
+		"sensiolabs/security-checker": "^5.0"
+	},
+	"scripts": {
+		"install-codestandards": [
+			"Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+		],
+		"post-install-cmd": [
+			"@install-codestandards"
+		],
+		"post-update-cmd": [
+			"@install-codestandards"
+		],
+		"lint": "vendor/bin/phpcs --report=full .",
+		"lint-fix": "vendor/bin/phpcbf"
+	},
+	"extra": {
+		"phpcodesniffer-search-depth": 5
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
 	],
 	"config": {
 		"platform": {
-			"php": "7.3"
+			"php": "7.4"
 		},
 		"optimize-autoloader": true
 	},
 	"require-dev": {
-		"php": ">=7.3.0",
+		"php": ">=7.4.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -1,1230 +1,1361 @@
 {
-  "_readme": [
-      "This file locks the dependencies of your project to a known state",
-      "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
-      "This file is @generated automatically"
-  ],
-  "content-hash": "d3b55e9ba9b5e39afeb0cd567e0d0424",
-  "packages": [],
-  "packages-dev": [
-      {
-          "name": "composer/ca-bundle",
-          "version": "1.2.9",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/composer/ca-bundle.git",
-              "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
-              "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
-              "shasum": ""
-          },
-          "require": {
-              "ext-openssl": "*",
-              "ext-pcre": "*",
-              "php": "^5.3.2 || ^7.0 || ^8.0"
-          },
-          "require-dev": {
-              "phpstan/phpstan": "^0.12.55",
-              "psr/log": "^1.0",
-              "symfony/phpunit-bridge": "^4.2 || ^5",
-              "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
-          },
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-main": "1.x-dev"
-              }
-          },
-          "autoload": {
-              "psr-4": {
-                  "Composer\\CaBundle\\": "src"
-              }
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Jordi Boggiano",
-                  "email": "j.boggiano@seld.be",
-                  "homepage": "http://seld.be"
-              }
-          ],
-          "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-          "keywords": [
-              "cabundle",
-              "cacert",
-              "certificate",
-              "ssl",
-              "tls"
-          ],
-          "funding": [
-              {
-                  "url": "https://packagist.com",
-                  "type": "custom"
-              },
-              {
-                  "url": "https://github.com/composer",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2021-01-12T12:10:35+00:00"
-      },
-      {
-          "name": "dealerdirect/phpcodesniffer-composer-installer",
-          "version": "v0.7.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-              "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-              "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
-              "shasum": ""
-          },
-          "require": {
-              "composer-plugin-api": "^1.0 || ^2.0",
-              "php": ">=5.3",
-              "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
-          },
-          "require-dev": {
-              "composer/composer": "*",
-              "phpcompatibility/php-compatibility": "^9.0",
-              "sensiolabs/security-checker": "^4.1.0"
-          },
-          "type": "composer-plugin",
-          "extra": {
-              "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
-          },
-          "autoload": {
-              "psr-4": {
-                  "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
-              }
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Franck Nijhof",
-                  "email": "franck.nijhof@dealerdirect.com",
-                  "homepage": "http://www.frenck.nl",
-                  "role": "Developer / IT Manager"
-              }
-          ],
-          "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-          "homepage": "http://www.dealerdirect.com",
-          "keywords": [
-              "PHPCodeSniffer",
-              "PHP_CodeSniffer",
-              "code quality",
-              "codesniffer",
-              "composer",
-              "installer",
-              "phpcs",
-              "plugin",
-              "qa",
-              "quality",
-              "standard",
-              "standards",
-              "style guide",
-              "stylecheck",
-              "tests"
-          ],
-          "time": "2020-12-07T18:04:37+00:00"
-      },
-      {
-          "name": "phpcompatibility/php-compatibility",
-          "version": "9.3.5",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-              "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
-              "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=5.3",
-              "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-          },
-          "conflict": {
-              "squizlabs/php_codesniffer": "2.6.2"
-          },
-          "require-dev": {
-              "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-          },
-          "suggest": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-              "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-          },
-          "type": "phpcodesniffer-standard",
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "LGPL-3.0-or-later"
-          ],
-          "authors": [
-              {
-                  "name": "Wim Godden",
-                  "homepage": "https://github.com/wimg",
-                  "role": "lead"
-              },
-              {
-                  "name": "Juliette Reinders Folmer",
-                  "homepage": "https://github.com/jrfnl",
-                  "role": "lead"
-              },
-              {
-                  "name": "Contributors",
-                  "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
-              }
-          ],
-          "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
-          "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-          "keywords": [
-              "compatibility",
-              "phpcs",
-              "standards"
-          ],
-          "time": "2019-12-27T09:44:58+00:00"
-      },
-      {
-          "name": "phpcompatibility/phpcompatibility-paragonie",
-          "version": "1.3.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-              "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-              "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
-              "shasum": ""
-          },
-          "require": {
-              "phpcompatibility/php-compatibility": "^9.0"
-          },
-          "require-dev": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-              "paragonie/random_compat": "dev-master",
-              "paragonie/sodium_compat": "dev-master"
-          },
-          "suggest": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-              "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-          },
-          "type": "phpcodesniffer-standard",
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "LGPL-3.0-or-later"
-          ],
-          "authors": [
-              {
-                  "name": "Wim Godden",
-                  "role": "lead"
-              },
-              {
-                  "name": "Juliette Reinders Folmer",
-                  "role": "lead"
-              }
-          ],
-          "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
-          "homepage": "http://phpcompatibility.com/",
-          "keywords": [
-              "compatibility",
-              "paragonie",
-              "phpcs",
-              "polyfill",
-              "standards"
-          ],
-          "time": "2021-02-15T10:24:51+00:00"
-      },
-      {
-          "name": "phpcompatibility/phpcompatibility-wp",
-          "version": "2.1.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-              "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
-              "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
-              "shasum": ""
-          },
-          "require": {
-              "phpcompatibility/php-compatibility": "^9.0",
-              "phpcompatibility/phpcompatibility-paragonie": "^1.0"
-          },
-          "require-dev": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
-          },
-          "suggest": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-              "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-          },
-          "type": "phpcodesniffer-standard",
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "LGPL-3.0-or-later"
-          ],
-          "authors": [
-              {
-                  "name": "Wim Godden",
-                  "role": "lead"
-              },
-              {
-                  "name": "Juliette Reinders Folmer",
-                  "role": "lead"
-              }
-          ],
-          "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
-          "homepage": "http://phpcompatibility.com/",
-          "keywords": [
-              "compatibility",
-              "phpcs",
-              "standards",
-              "wordpress"
-          ],
-          "time": "2021-02-15T12:58:46+00:00"
-      },
-      {
-          "name": "psr/container",
-          "version": "1.1.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/php-fig/container.git",
-              "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-              "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=7.2.0"
-          },
-          "type": "library",
-          "autoload": {
-              "psr-4": {
-                  "Psr\\Container\\": "src/"
-              }
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "PHP-FIG",
-                  "homepage": "https://www.php-fig.org/"
-              }
-          ],
-          "description": "Common Container Interface (PHP FIG PSR-11)",
-          "homepage": "https://github.com/php-fig/container",
-          "keywords": [
-              "PSR-11",
-              "container",
-              "container-interface",
-              "container-interop",
-              "psr"
-          ],
-          "time": "2021-03-05T17:36:06+00:00"
-      },
-      {
-          "name": "roave/security-advisories",
-          "version": "dev-master",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/Roave/SecurityAdvisories.git",
-              "reference": "0745f820eed6cb92603ca44a9c137ff8ce315e86"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0745f820eed6cb92603ca44a9c137ff8ce315e86",
-              "reference": "0745f820eed6cb92603ca44a9c137ff8ce315e86",
-              "shasum": ""
-          },
-          "conflict": {
-              "3f/pygmentize": "<1.2",
-              "adodb/adodb-php": "<5.20.12",
-              "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
-              "amphp/artax": "<1.0.6|>=2,<2.0.6",
-              "amphp/http": "<1.0.1",
-              "amphp/http-client": ">=4,<4.4",
-              "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
-              "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
-              "aws/aws-sdk-php": ">=3,<3.2.1",
-              "bagisto/bagisto": "<0.1.5",
-              "barrelstrength/sprout-base-email": "<1.2.7",
-              "barrelstrength/sprout-forms": "<3.9",
-              "baserproject/basercms": ">=4,<=4.3.6|>=4.4,<4.4.1",
-              "bolt/bolt": "<3.7.1",
-              "bolt/core": "<4.1.13",
-              "brightlocal/phpwhois": "<=4.2.5",
-              "buddypress/buddypress": "<5.1.2",
-              "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-              "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
-              "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
-              "cartalyst/sentry": "<=2.1.6",
-              "centreon/centreon": "<18.10.8|>=19,<19.4.5",
-              "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
-              "codeigniter/framework": "<=3.0.6",
-              "composer/composer": "<=1-alpha.11",
-              "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-              "contao/core": ">=2,<3.5.39",
-              "contao/core-bundle": ">=4,<4.4.52|>=4.5,<4.9.6|= 4.10.0",
-              "contao/listing-bundle": ">=4,<4.4.8",
-              "datadog/dd-trace": ">=0.30,<0.30.2",
-              "david-garcia/phpwhois": "<=4.3.1",
-              "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
-              "doctrine/annotations": ">=1,<1.2.7",
-              "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
-              "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
-              "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
-              "doctrine/doctrine-bundle": "<1.5.2",
-              "doctrine/doctrine-module": "<=0.7.1",
-              "doctrine/mongodb-odm": ">=1,<1.0.2",
-              "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
-              "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
-              "dolibarr/dolibarr": "<11.0.4",
-              "dompdf/dompdf": ">=0.6,<0.6.2",
-              "drupal/core": ">=7,<7.74|>=8,<8.8.11|>=8.9,<8.9.9|>=9,<9.0.8",
-              "drupal/drupal": ">=7,<7.74|>=8,<8.8.11|>=8.9,<8.9.9|>=9,<9.0.8",
-              "endroid/qr-code-bundle": "<3.4.2",
-              "enshrined/svg-sanitize": "<0.13.1",
-              "erusev/parsedown": "<1.7.2",
-              "ezsystems/demobundle": ">=5.4,<5.4.6.1",
-              "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
-              "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
-              "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
-              "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
-              "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
-              "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
-              "ezsystems/ezplatform-kernel": ">=1,<1.0.2.1",
-              "ezsystems/ezplatform-user": ">=1,<1.0.1",
-              "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.2|>=6,<6.7.9.1|>=6.8,<6.13.6.3|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.7.1",
-              "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.2|>=2011,<2017.12.7.3|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.5.1",
-              "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
-              "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
-              "ezyang/htmlpurifier": "<4.1.1",
-              "facade/ignition": "<=2.5.1,>=2.0|<=1.16.13",
-              "firebase/php-jwt": "<2",
-              "flarum/sticky": ">=0.1-beta.14,<=0.1-beta.15",
-              "flarum/tags": "<=0.1-beta.13",
-              "fooman/tcpdf": "<6.2.22",
-              "fossar/tcpdf-parser": "<6.2.22",
-              "friendsofsymfony/oauth2-php": "<1.3",
-              "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
-              "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
-              "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
-              "fuel/core": "<1.8.1",
-              "getgrav/grav": "<1.7-beta.8",
-              "getkirby/cms": ">=3,<3.4.5",
-              "getkirby/panel": "<2.5.14",
-              "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
-              "gree/jose": "<=2.2",
-              "gregwar/rst": "<1.0.3",
-              "guzzlehttp/guzzle": ">=4-rc.2,<4.2.4|>=5,<5.3.1|>=6,<6.2.1",
-              "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
-              "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
-              "illuminate/database": "<6.20.14|>=7,<7.30.4|>=8,<8.24",
-              "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
-              "illuminate/view": ">=7,<7.1.2",
-              "ivankristianto/phpwhois": "<=4.3",
-              "james-heinrich/getid3": "<1.9.9",
-              "joomla/session": "<1.3.1",
-              "jsmitty12/phpwhois": "<5.1",
-              "kazist/phpwhois": "<=4.2.6",
-              "kitodo/presentation": "<3.1.2",
-              "kreait/firebase-php": ">=3.2,<3.8.1",
-              "la-haute-societe/tcpdf": "<6.2.22",
-              "laravel/framework": "<6.20.14|>=7,<7.30.4|>=8,<8.24",
-              "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
-              "league/commonmark": "<0.18.3",
-              "librenms/librenms": "<1.53",
-              "livewire/livewire": ">2.2.4,<2.2.6",
-              "magento/community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
-              "magento/magento1ce": "<1.9.4.3",
-              "magento/magento1ee": ">=1,<1.14.4.3",
-              "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
-              "marcwillmann/turn": "<0.3.3",
-              "mautic/core": "<2.16.5|>=3,<3.2.4|= 2.13.1",
-              "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
-              "mittwald/typo3_forum": "<1.2.1",
-              "monolog/monolog": ">=1.8,<1.12",
-              "namshi/jose": "<2.2",
-              "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
-              "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
-              "nystudio107/craft-seomatic": "<3.3",
-              "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
-              "october/backend": ">=1.0.319,<1.0.470",
-              "october/cms": "= 1.0.469|>=1.0.319,<1.0.469",
-              "october/october": ">=1.0.319,<1.0.466",
-              "october/rain": "<1.0.472|>=1.1,<1.1.2",
-              "onelogin/php-saml": "<2.10.4",
-              "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
-              "openid/php-openid": "<2.3",
-              "openmage/magento-lts": "<19.4.8|>=20,<20.0.4",
-              "orchid/platform": ">=9,<9.4.4",
-              "oro/crm": ">=1.7,<1.7.4",
-              "oro/platform": ">=1.7,<1.7.4",
-              "padraic/humbug_get_contents": "<1.1.2",
-              "pagarme/pagarme-php": ">=0,<3",
-              "paragonie/random_compat": "<2",
-              "passbolt/passbolt_api": "<2.11",
-              "paypal/merchant-sdk-php": "<3.12",
-              "pear/archive_tar": "<1.4.12",
-              "personnummer/personnummer": "<3.0.2",
-              "phpfastcache/phpfastcache": ">=5,<5.0.13",
-              "phpmailer/phpmailer": "<6.1.6",
-              "phpmussel/phpmussel": ">=1,<1.6",
-              "phpmyadmin/phpmyadmin": "<4.9.6|>=5,<5.0.3",
-              "phpoffice/phpexcel": "<1.8.2",
-              "phpoffice/phpspreadsheet": "<1.16",
-              "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
-              "phpwhois/phpwhois": "<=4.2.5",
-              "phpxmlrpc/extras": "<0.6.1",
-              "pimcore/pimcore": "<6.8.8",
-              "pocketmine/pocketmine-mp": "<3.15.4",
-              "prestashop/autoupgrade": ">=4,<4.10.1",
-              "prestashop/contactform": ">1.0.1,<4.3",
-              "prestashop/gamification": "<2.3.2",
-              "prestashop/productcomments": ">=4,<4.2.1",
-              "prestashop/ps_facetedsearch": "<3.4.1",
-              "privatebin/privatebin": "<1.2.2|>=1.3,<1.3.2",
-              "propel/propel": ">=2-alpha.1,<=2-alpha.7",
-              "propel/propel1": ">=1,<=1.7.1",
-              "pterodactyl/panel": "<0.7.19|>=1-rc.0,<=1-rc.6",
-              "pusher/pusher-php-server": "<2.2.1",
-              "rainlab/debugbar-plugin": "<3.1",
-              "robrichards/xmlseclibs": "<3.0.4",
-              "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
-              "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
-              "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
-              "sensiolabs/connect": "<4.2.3",
-              "serluck/phpwhois": "<=4.2.6",
-              "shopware/core": "<=6.3.4",
-              "shopware/platform": "<=6.3.5",
-              "shopware/shopware": "<5.6.9",
-              "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
-              "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
-              "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
-              "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
-              "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-              "silverstripe/framework": "<4.4.7|>=4.5,<4.5.4",
-              "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.1.2|>=3.2,<3.2.4",
-              "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
-              "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
-              "silverstripe/subsites": ">=2,<2.1.1",
-              "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
-              "silverstripe/userforms": "<3",
-              "simple-updates/phpwhois": "<=1",
-              "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
-              "simplesamlphp/simplesamlphp": "<1.18.6",
-              "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
-              "simplito/elliptic-php": "<1.0.6",
-              "slim/slim": "<2.6",
-              "smarty/smarty": "<3.1.39",
-              "socalnick/scn-social-auth": "<1.15.2",
-              "socialiteproviders/steam": "<1.1",
-              "spoonity/tcpdf": "<6.2.22",
-              "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
-              "ssddanbrown/bookstack": "<0.29.2",
-              "stormpath/sdk": ">=0,<9.9.99",
-              "studio-42/elfinder": "<2.1.49",
-              "sulu/sulu": "<1.6.34|>=2,<2.0.10|>=2.1,<2.1.1",
-              "swiftmailer/swiftmailer": ">=4,<5.4.5",
-              "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
-              "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
-              "sylius/grid-bundle": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
-              "sylius/resource-bundle": "<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
-              "sylius/sylius": "<1.6.9|>=1.7,<1.7.9|>=1.8,<1.8.3",
-              "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
-              "symbiote/silverstripe-versionedfiles": "<=2.0.3",
-              "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
-              "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-              "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
-              "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
-              "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-              "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
-              "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
-              "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
-              "symfony/mime": ">=4.3,<4.3.8",
-              "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-              "symfony/polyfill": ">=1,<1.10",
-              "symfony/polyfill-php55": ">=1,<1.10",
-              "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
-              "symfony/routing": ">=2,<2.0.19",
-              "symfony/security": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=4.4,<4.4.7|>=5,<5.0.7",
-              "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
-              "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<2.8.37|>=3,<3.3.17|>=3.4,<3.4.7|>=4,<4.0.7",
-              "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
-              "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
-              "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
-              "symfony/serializer": ">=2,<2.0.11",
-              "symfony/symfony": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
-              "symfony/translation": ">=2,<2.0.17",
-              "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
-              "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
-              "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
-              "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
-              "t3g/svg-sanitizer": "<1.0.3",
-              "tecnickcom/tcpdf": "<6.2.22",
-              "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-              "thelia/thelia": ">=2.1-beta.1,<2.1.3",
-              "theonedemon/phpwhois": "<=4.2.5",
-              "titon/framework": ">=0,<9.9.99",
-              "truckersmp/phpwhois": "<=4.3.1",
-              "twig/twig": "<1.38|>=2,<2.7",
-              "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.23|>=10,<10.4.10",
-              "typo3/cms-core": ">=8,<8.7.38|>=9,<9.5.23|>=10,<10.4.10",
-              "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
-              "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
-              "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
-              "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
-              "ua-parser/uap-php": "<3.8",
-              "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
-              "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
-              "vrana/adminer": "<4.7.9",
-              "wallabag/tcpdf": "<6.2.22",
-              "willdurand/js-translation-bundle": "<2.1.1",
-              "yii2mod/yii2-cms": "<1.9.2",
-              "yiisoft/yii": ">=1.1.14,<1.1.15",
-              "yiisoft/yii2": "<2.0.38",
-              "yiisoft/yii2-bootstrap": "<2.0.4",
-              "yiisoft/yii2-dev": "<2.0.15",
-              "yiisoft/yii2-elasticsearch": "<2.0.5",
-              "yiisoft/yii2-gii": "<2.0.4",
-              "yiisoft/yii2-jui": "<2.0.4",
-              "yiisoft/yii2-redis": "<2.0.8",
-              "yourls/yourls": "<1.7.4",
-              "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
-              "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
-              "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
-              "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
-              "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
-              "zendframework/zend-diactoros": ">=1,<1.8.4",
-              "zendframework/zend-feed": ">=1,<2.10.3",
-              "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
-              "zendframework/zend-http": ">=1,<2.8.1",
-              "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-              "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
-              "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
-              "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
-              "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
-              "zendframework/zend-validator": ">=2.3,<2.3.6",
-              "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
-              "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-              "zendframework/zendframework": "<2.5.1",
-              "zendframework/zendframework1": "<1.12.20",
-              "zendframework/zendopenid": ">=2,<2.0.2",
-              "zendframework/zendxml": ">=1,<1.0.1",
-              "zetacomponents/mail": "<1.8.2",
-              "zf-commons/zfc-user": "<1.2.2",
-              "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
-              "zfr/zfr-oauth2-server-module": "<0.1.2"
-          },
-          "type": "metapackage",
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Marco Pivetta",
-                  "email": "ocramius@gmail.com",
-                  "role": "maintainer"
-              },
-              {
-                  "name": "Ilya Tribusean",
-                  "email": "slash3b@gmail.com",
-                  "role": "maintainer"
-              }
-          ],
-          "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-          "funding": [
-              {
-                  "url": "https://github.com/Ocramius",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2021-03-03T23:02:20+00:00"
-      },
-      {
-          "name": "sensiolabs/security-checker",
-          "version": "v5.0.3",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/sensiolabs/security-checker.git",
-              "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
-              "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
-              "shasum": ""
-          },
-          "require": {
-              "composer/ca-bundle": "^1.0",
-              "php": ">=5.5.9",
-              "symfony/console": "~2.7|~3.0|~4.0"
-          },
-          "bin": [
-              "security-checker"
-          ],
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-master": "5.0-dev"
-              }
-          },
-          "autoload": {
-              "psr-4": {
-                  "SensioLabs\\Security\\": "SensioLabs/Security"
-              }
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Fabien Potencier",
-                  "email": "fabien.potencier@gmail.com"
-              }
-          ],
-          "description": "A security checker for your composer.lock",
-          "abandoned": "https://github.com/fabpot/local-php-security-checker",
-          "time": "2018-12-19T17:14:59+00:00"
-      },
-      {
-          "name": "squizlabs/php_codesniffer",
-          "version": "3.5.8",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-              "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-              "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
-              "shasum": ""
-          },
-          "require": {
-              "ext-simplexml": "*",
-              "ext-tokenizer": "*",
-              "ext-xmlwriter": "*",
-              "php": ">=5.4.0"
-          },
-          "require-dev": {
-              "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-          },
-          "bin": [
-              "bin/phpcs",
-              "bin/phpcbf"
-          ],
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-master": "3.x-dev"
-              }
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "BSD-3-Clause"
-          ],
-          "authors": [
-              {
-                  "name": "Greg Sherwood",
-                  "role": "lead"
-              }
-          ],
-          "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-          "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-          "keywords": [
-              "phpcs",
-              "standards"
-          ],
-          "time": "2020-10-23T02:01:07+00:00"
-      },
-      {
-          "name": "symfony/console",
-          "version": "v4.4.20",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/symfony/console.git",
-              "reference": "c98349bda966c70d6c08b4cd8658377c94166492"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/symfony/console/zipball/c98349bda966c70d6c08b4cd8658377c94166492",
-              "reference": "c98349bda966c70d6c08b4cd8658377c94166492",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=7.1.3",
-              "symfony/polyfill-mbstring": "~1.0",
-              "symfony/polyfill-php73": "^1.8",
-              "symfony/polyfill-php80": "^1.15",
-              "symfony/service-contracts": "^1.1|^2"
-          },
-          "conflict": {
-              "symfony/dependency-injection": "<3.4",
-              "symfony/event-dispatcher": "<4.3|>=5",
-              "symfony/lock": "<4.4",
-              "symfony/process": "<3.3"
-          },
-          "provide": {
-              "psr/log-implementation": "1.0"
-          },
-          "require-dev": {
-              "psr/log": "~1.0",
-              "symfony/config": "^3.4|^4.0|^5.0",
-              "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-              "symfony/event-dispatcher": "^4.3",
-              "symfony/lock": "^4.4|^5.0",
-              "symfony/process": "^3.4|^4.0|^5.0",
-              "symfony/var-dumper": "^4.3|^5.0"
-          },
-          "suggest": {
-              "psr/log": "For using the console logger",
-              "symfony/event-dispatcher": "",
-              "symfony/lock": "",
-              "symfony/process": ""
-          },
-          "type": "library",
-          "autoload": {
-              "psr-4": {
-                  "Symfony\\Component\\Console\\": ""
-              },
-              "exclude-from-classmap": [
-                  "/Tests/"
-              ]
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Fabien Potencier",
-                  "email": "fabien@symfony.com"
-              },
-              {
-                  "name": "Symfony Community",
-                  "homepage": "https://symfony.com/contributors"
-              }
-          ],
-          "description": "Eases the creation of beautiful and testable command line interfaces",
-          "homepage": "https://symfony.com",
-          "funding": [
-              {
-                  "url": "https://symfony.com/sponsor",
-                  "type": "custom"
-              },
-              {
-                  "url": "https://github.com/fabpot",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2021-02-22T18:44:15+00:00"
-      },
-      {
-          "name": "symfony/polyfill-mbstring",
-          "version": "v1.22.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/symfony/polyfill-mbstring.git",
-              "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-              "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=7.1"
-          },
-          "suggest": {
-              "ext-mbstring": "For best performance"
-          },
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-main": "1.22-dev"
-              },
-              "thanks": {
-                  "name": "symfony/polyfill",
-                  "url": "https://github.com/symfony/polyfill"
-              }
-          },
-          "autoload": {
-              "psr-4": {
-                  "Symfony\\Polyfill\\Mbstring\\": ""
-              },
-              "files": [
-                  "bootstrap.php"
-              ]
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Nicolas Grekas",
-                  "email": "p@tchwork.com"
-              },
-              {
-                  "name": "Symfony Community",
-                  "homepage": "https://symfony.com/contributors"
-              }
-          ],
-          "description": "Symfony polyfill for the Mbstring extension",
-          "homepage": "https://symfony.com",
-          "keywords": [
-              "compatibility",
-              "mbstring",
-              "polyfill",
-              "portable",
-              "shim"
-          ],
-          "funding": [
-              {
-                  "url": "https://symfony.com/sponsor",
-                  "type": "custom"
-              },
-              {
-                  "url": "https://github.com/fabpot",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2021-01-22T09:19:47+00:00"
-      },
-      {
-          "name": "symfony/polyfill-php73",
-          "version": "v1.22.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/symfony/polyfill-php73.git",
-              "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-              "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=7.1"
-          },
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-main": "1.22-dev"
-              },
-              "thanks": {
-                  "name": "symfony/polyfill",
-                  "url": "https://github.com/symfony/polyfill"
-              }
-          },
-          "autoload": {
-              "psr-4": {
-                  "Symfony\\Polyfill\\Php73\\": ""
-              },
-              "files": [
-                  "bootstrap.php"
-              ],
-              "classmap": [
-                  "Resources/stubs"
-              ]
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Nicolas Grekas",
-                  "email": "p@tchwork.com"
-              },
-              {
-                  "name": "Symfony Community",
-                  "homepage": "https://symfony.com/contributors"
-              }
-          ],
-          "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-          "homepage": "https://symfony.com",
-          "keywords": [
-              "compatibility",
-              "polyfill",
-              "portable",
-              "shim"
-          ],
-          "funding": [
-              {
-                  "url": "https://symfony.com/sponsor",
-                  "type": "custom"
-              },
-              {
-                  "url": "https://github.com/fabpot",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2021-01-07T16:49:33+00:00"
-      },
-      {
-          "name": "symfony/polyfill-php80",
-          "version": "v1.22.1",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/symfony/polyfill-php80.git",
-              "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-              "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=7.1"
-          },
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-main": "1.22-dev"
-              },
-              "thanks": {
-                  "name": "symfony/polyfill",
-                  "url": "https://github.com/symfony/polyfill"
-              }
-          },
-          "autoload": {
-              "psr-4": {
-                  "Symfony\\Polyfill\\Php80\\": ""
-              },
-              "files": [
-                  "bootstrap.php"
-              ],
-              "classmap": [
-                  "Resources/stubs"
-              ]
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Ion Bazan",
-                  "email": "ion.bazan@gmail.com"
-              },
-              {
-                  "name": "Nicolas Grekas",
-                  "email": "p@tchwork.com"
-              },
-              {
-                  "name": "Symfony Community",
-                  "homepage": "https://symfony.com/contributors"
-              }
-          ],
-          "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-          "homepage": "https://symfony.com",
-          "keywords": [
-              "compatibility",
-              "polyfill",
-              "portable",
-              "shim"
-          ],
-          "funding": [
-              {
-                  "url": "https://symfony.com/sponsor",
-                  "type": "custom"
-              },
-              {
-                  "url": "https://github.com/fabpot",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2021-01-07T16:49:33+00:00"
-      },
-      {
-          "name": "symfony/service-contracts",
-          "version": "v2.2.0",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/symfony/service-contracts.git",
-              "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-              "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=7.2.5",
-              "psr/container": "^1.0"
-          },
-          "suggest": {
-              "symfony/service-implementation": ""
-          },
-          "type": "library",
-          "extra": {
-              "branch-alias": {
-                  "dev-master": "2.2-dev"
-              },
-              "thanks": {
-                  "name": "symfony/contracts",
-                  "url": "https://github.com/symfony/contracts"
-              }
-          },
-          "autoload": {
-              "psr-4": {
-                  "Symfony\\Contracts\\Service\\": ""
-              }
-          },
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Nicolas Grekas",
-                  "email": "p@tchwork.com"
-              },
-              {
-                  "name": "Symfony Community",
-                  "homepage": "https://symfony.com/contributors"
-              }
-          ],
-          "description": "Generic abstractions related to writing services",
-          "homepage": "https://symfony.com",
-          "keywords": [
-              "abstractions",
-              "contracts",
-              "decoupling",
-              "interfaces",
-              "interoperability",
-              "standards"
-          ],
-          "funding": [
-              {
-                  "url": "https://symfony.com/sponsor",
-                  "type": "custom"
-              },
-              {
-                  "url": "https://github.com/fabpot",
-                  "type": "github"
-              },
-              {
-                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                  "type": "tidelift"
-              }
-          ],
-          "time": "2020-09-07T11:33:47+00:00"
-      },
-      {
-          "name": "wp-coding-standards/wpcs",
-          "version": "2.3.0",
-          "source": {
-              "type": "git",
-              "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-              "reference": "7da1894633f168fe244afc6de00d141f27517b62"
-          },
-          "dist": {
-              "type": "zip",
-              "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-              "reference": "7da1894633f168fe244afc6de00d141f27517b62",
-              "shasum": ""
-          },
-          "require": {
-              "php": ">=5.4",
-              "squizlabs/php_codesniffer": "^3.3.1"
-          },
-          "require-dev": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-              "phpcompatibility/php-compatibility": "^9.0",
-              "phpcsstandards/phpcsdevtools": "^1.0",
-              "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-          },
-          "suggest": {
-              "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
-          },
-          "type": "phpcodesniffer-standard",
-          "notification-url": "https://packagist.org/downloads/",
-          "license": [
-              "MIT"
-          ],
-          "authors": [
-              {
-                  "name": "Contributors",
-                  "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
-              }
-          ],
-          "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
-          "keywords": [
-              "phpcs",
-              "standards",
-              "wordpress"
-          ],
-          "time": "2020-05-13T23:57:56+00:00"
-      }
-  ],
-  "aliases": [],
-  "minimum-stability": "stable",
-  "stability-flags": {
-      "roave/security-advisories": 20
-  },
-  "prefer-stable": false,
-  "prefer-lowest": false,
-  "platform": [],
-  "platform-dev": {
-      "php": ">=7.3.0"
-  },
-  "platform-overrides": {
-      "php": "7.3"
-  },
-  "plugin-api-version": "1.1.0"
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "af073c590a1350849569b5c7ee87ec21",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "psr/log": "^1.0",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-12T12:10:35+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2021-02-15T10:24:51+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2021-02-15T12:58:46+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "roave/security-advisories",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "0745f820eed6cb92603ca44a9c137ff8ce315e86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0745f820eed6cb92603ca44a9c137ff8ce315e86",
+                "reference": "0745f820eed6cb92603ca44a9c137ff8ce315e86",
+                "shasum": ""
+            },
+            "conflict": {
+                "3f/pygmentize": "<1.2",
+                "adodb/adodb-php": "<5.20.12",
+                "akaunting/akaunting": "<2.1.13",
+                "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+                "amazing/media2click": ">=1,<1.3.3",
+                "amphp/artax": "<1.0.6|>=2,<2.0.6",
+                "amphp/http": "<1.0.1",
+                "amphp/http-client": ">=4,<4.4",
+                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
+                "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
+                "aws/aws-sdk-php": ">=3,<3.2.1",
+                "bagisto/bagisto": "<0.1.5",
+                "barrelstrength/sprout-base-email": "<1.2.7",
+                "barrelstrength/sprout-forms": "<3.9",
+                "baserproject/basercms": "<=4.5",
+                "billz/raspap-webgui": "<=2.6.6",
+                "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
+                "bolt/bolt": "<3.7.2",
+                "bolt/core": "<4.1.13",
+                "brightlocal/phpwhois": "<=4.2.5",
+                "buddypress/buddypress": "<5.1.2",
+                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "cachethq/cachet": "<2.5.1",
+                "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
+                "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+                "cartalyst/sentry": "<=2.1.6",
+                "centreon/centreon": "<20.10.7",
+                "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+                "codeception/codeception": "<3.1.3|>=4,<4.1.22",
+                "codeigniter/framework": "<=3.0.6",
+                "codiad/codiad": "<=2.8.4",
+                "composer/composer": "<1.10.22|>=2-alpha.1,<2.0.13",
+                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/core": ">=2,<3.5.39",
+                "contao/core-bundle": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|= 4.10.0",
+                "contao/listing-bundle": ">=4,<4.4.8",
+                "craftcms/cms": "<3.6.7",
+                "croogo/croogo": "<3.0.7",
+                "datadog/dd-trace": ">=0.30,<0.30.2",
+                "david-garcia/phpwhois": "<=4.3.1",
+                "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
+                "directmailteam/direct-mail": "<5.2.4",
+                "doctrine/annotations": ">=1,<1.2.7",
+                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
+                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
+                "doctrine/doctrine-bundle": "<1.5.2",
+                "doctrine/doctrine-module": "<=0.7.1",
+                "doctrine/mongodb-odm": ">=1,<1.0.2",
+                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
+                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
+                "dolibarr/dolibarr": "<14|>= 3.3.beta1, < 13.0.2",
+                "dompdf/dompdf": ">=0.6,<0.6.2",
+                "drupal/core": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
+                "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
+                "dweeves/magmi": "<=0.7.24",
+                "ecodev/newsletter": "<=4",
+                "endroid/qr-code-bundle": "<3.4.2",
+                "enshrined/svg-sanitize": "<0.13.1",
+                "erusev/parsedown": "<1.7.2",
+                "ether/logs": "<3.0.4",
+                "ezsystems/demobundle": ">=5.4,<5.4.6.1",
+                "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
+                "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
+                "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
+                "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+                "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<=1.3.1",
+                "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<=1.3.1",
+                "ezsystems/ezplatform-user": ">=1,<1.0.1",
+                "ezsystems/ezpublish-kernel": "<=6.13.8.1|>=7,<=7.5.15.1",
+                "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.3.5.1",
+                "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
+                "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
+                "ezyang/htmlpurifier": "<4.1.1",
+                "facade/ignition": "<1.16.14|>=2,<2.4.2|>=2.5,<2.5.2",
+                "feehi/cms": "<=2.1.1",
+                "feehi/feehicms": "<=0.1.3",
+                "firebase/php-jwt": "<2",
+                "flarum/core": ">=1,<=1.0.1",
+                "flarum/sticky": ">=0.1-beta.14,<=0.1-beta.15",
+                "flarum/tags": "<=0.1-beta.13",
+                "fluidtypo3/vhs": "<5.1.1",
+                "fooman/tcpdf": "<6.2.22",
+                "forkcms/forkcms": "<=5.9.2",
+                "fossar/tcpdf-parser": "<6.2.22",
+                "francoisjacquet/rosariosis": "<6.5.1",
+                "friendsofsymfony/oauth2-php": "<1.3",
+                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+                "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+                "froala/wysiwyg-editor": "<3.2.7",
+                "fuel/core": "<1.8.1",
+                "getgrav/grav": "<=1.7.10",
+                "getkirby/cms": "<=3.5.6",
+                "getkirby/panel": "<2.5.14",
+                "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
+                "gree/jose": "<=2.2",
+                "gregwar/rst": "<1.0.3",
+                "grumpydictator/firefly-iii": "<5.6",
+                "guzzlehttp/guzzle": ">=4-rc.2,<4.2.4|>=5,<5.3.1|>=6,<6.2.1",
+                "helloxz/imgurl": "<=2.31",
+                "ibexa/post-install": "<=1.0.4",
+                "icecoder/icecoder": "<=8",
+                "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
+                "illuminate/database": "<6.20.26|>=7,<8.40",
+                "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "illuminate/view": ">=7,<7.1.2",
+                "impresscms/impresscms": "<=1.4.2",
+                "in2code/femanager": "<5.5.1|>=6,<6.3.1",
+                "intelliants/subrion": "<=4.2.1",
+                "ivankristianto/phpwhois": "<=4.3",
+                "james-heinrich/getid3": "<1.9.9",
+                "joomla/archive": "<1.1.10",
+                "joomla/session": "<1.3.1",
+                "jsmitty12/phpwhois": "<5.1",
+                "kazist/phpwhois": "<=4.2.6",
+                "kitodo/presentation": "<3.1.2",
+                "klaviyo/magento2-extension": ">=1,<3",
+                "kreait/firebase-php": ">=3.2,<3.8.1",
+                "la-haute-societe/tcpdf": "<6.2.22",
+                "laminas/laminas-http": "<2.14.2",
+                "laravel/framework": "<6.20.26|>=7,<8.40",
+                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
+                "lavalite/cms": "<=5.8",
+                "league/commonmark": "<0.18.3",
+                "league/flysystem": "<1.1.4|>=2,<2.1.1",
+                "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
+                "librenms/librenms": "<21.1",
+                "livewire/livewire": ">2.2.4,<2.2.6",
+                "lms/routes": "<2.1.1",
+                "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
+                "magento/community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
+                "magento/magento1ce": "<1.9.4.3",
+                "magento/magento1ee": ">=1,<1.14.4.3",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
+                "marcwillmann/turn": "<0.3.3",
+                "mautic/core": "<4|= 2.13.1",
+                "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
+                "miniorange/miniorange-saml": "<1.4.3",
+                "mittwald/typo3_forum": "<1.2.1",
+                "monolog/monolog": ">=1.8,<1.12",
+                "moodle/moodle": "<3.5.17|>=3.7,<3.7.9|>=3.8,<3.8.8|>=3.9,<3.9.5|>=3.10,<3.10.2",
+                "namshi/jose": "<2.2",
+                "neos/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "neos/form": ">=1.2,<4.3.3|>=5,<5.0.9|>=5.1,<5.1.3",
+                "neos/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.9.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
+                "neos/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
+                "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+                "nilsteampassnet/teampass": "<=2.1.27.36",
+                "nukeviet/nukeviet": "<4.3.4",
+                "nystudio107/craft-seomatic": "<3.3",
+                "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+                "october/backend": "<1.1.2",
+                "october/cms": "= 1.1.1|= 1.0.471|= 1.0.469|>=1.0.319,<1.0.469",
+                "october/october": ">=1.0.319,<1.0.466",
+                "october/rain": "<1.0.472|>=1.1,<1.1.2",
+                "october/system": "<1.0.472|>=1.1.1,<1.1.5",
+                "onelogin/php-saml": "<2.10.4",
+                "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
+                "opencart/opencart": "<=3.0.3.2",
+                "openid/php-openid": "<2.3",
+                "openmage/magento-lts": "<19.4.15|>=20,<20.0.13",
+                "orchid/platform": ">=9,<9.4.4",
+                "oro/crm": ">=1.7,<1.7.4",
+                "oro/platform": ">=1.7,<1.7.4",
+                "padraic/humbug_get_contents": "<1.1.2",
+                "pagarme/pagarme-php": ">=0,<3",
+                "pagekit/pagekit": "<=1.0.18",
+                "paragonie/random_compat": "<2",
+                "passbolt/passbolt_api": "<2.11",
+                "paypal/merchant-sdk-php": "<3.12",
+                "pear/archive_tar": "<1.4.14",
+                "personnummer/personnummer": "<3.0.2",
+                "phanan/koel": "<5.1.4",
+                "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
+                "phpmailer/phpmailer": "<6.5",
+                "phpmussel/phpmussel": ">=1,<1.6",
+                "phpmyadmin/phpmyadmin": "<4.9.6|>=5,<5.0.3",
+                "phpoffice/phpexcel": "<1.8.2",
+                "phpoffice/phpspreadsheet": "<1.16",
+                "phpseclib/phpseclib": "<2.0.31|>=3,<3.0.7",
+                "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
+                "phpwhois/phpwhois": "<=4.2.5",
+                "phpxmlrpc/extras": "<0.6.1",
+                "pimcore/pimcore": "<10.1.3",
+                "pocketmine/pocketmine-mp": "<3.15.4",
+                "pressbooks/pressbooks": "<5.18",
+                "prestashop/autoupgrade": ">=4,<4.10.1",
+                "prestashop/contactform": ">1.0.1,<4.3",
+                "prestashop/gamification": "<2.3.2",
+                "prestashop/productcomments": ">=4,<4.2.1",
+                "prestashop/ps_emailsubscription": "<2.6.1",
+                "prestashop/ps_facetedsearch": "<3.4.1",
+                "privatebin/privatebin": "<1.2.2|>=1.3,<1.3.2",
+                "propel/propel": ">=2-alpha.1,<=2-alpha.7",
+                "propel/propel1": ">=1,<=1.7.1",
+                "pterodactyl/panel": "<0.7.19|>=1-rc.0,<=1-rc.6",
+                "pusher/pusher-php-server": "<2.2.1",
+                "pwweb/laravel-core": "<=0.3.6-beta",
+                "rainlab/debugbar-plugin": "<3.1",
+                "rmccue/requests": ">=1.6,<1.8",
+                "robrichards/xmlseclibs": "<3.0.4",
+                "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
+                "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
+                "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
+                "sensiolabs/connect": "<4.2.3",
+                "serluck/phpwhois": "<=4.2.6",
+                "shopware/core": "<=6.4.3",
+                "shopware/platform": "<=6.4.3",
+                "shopware/production": "<=6.3.5.2",
+                "shopware/shopware": "<5.6.10",
+                "showdoc/showdoc": "<=2.9.8",
+                "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
+                "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
+                "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
+                "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
+                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+                "silverstripe/framework": "<4.7.4",
+                "silverstripe/graphql": "<=3.5|>=4-alpha.1,<4-alpha.2",
+                "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+                "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
+                "silverstripe/subsites": ">=2,<2.1.1",
+                "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+                "silverstripe/userforms": "<3",
+                "simple-updates/phpwhois": "<=1",
+                "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
+                "simplesamlphp/simplesamlphp": "<1.18.6",
+                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+                "simplito/elliptic-php": "<1.0.6",
+                "slim/slim": "<2.6",
+                "smarty/smarty": "<3.1.39",
+                "socalnick/scn-social-auth": "<1.15.2",
+                "socialiteproviders/steam": "<1.1",
+                "spoonity/tcpdf": "<6.2.22",
+                "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+                "ssddanbrown/bookstack": "<0.29.2",
+                "stormpath/sdk": ">=0,<9.9.99",
+                "studio-42/elfinder": "<2.1.59",
+                "subrion/cms": "<=4.2.1",
+                "sulu/sulu": "<1.6.41|>=2,<2.0.10|>=2.1,<2.1.1",
+                "swiftmailer/swiftmailer": ">=4,<5.4.5",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/grid-bundle": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+                "sylius/resource-bundle": "<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
+                "sylius/sylius": "<1.6.9|>=1.7,<1.7.9|>=1.8,<1.8.3|>=1.9,<1.9.5",
+                "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
+                "symbiote/silverstripe-queuedjobs": ">=3,<3.0.2|>=3.1,<3.1.4|>=4,<4.0.7|>=4.1,<4.1.2|>=4.2,<4.2.4|>=4.3,<4.3.3|>=4.4,<4.4.3|>=4.5,<4.5.1|>=4.6,<4.6.4",
+                "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+                "symfont/process": ">=0,<4",
+                "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+                "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+                "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
+                "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+                "symfony/maker-bundle": ">=1.27,<1.29.2|>=1.30,<1.31.1",
+                "symfony/mime": ">=4.3,<4.3.8",
+                "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/polyfill": ">=1,<1.10",
+                "symfony/polyfill-php55": ">=1,<1.10",
+                "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/routing": ">=2,<2.0.19",
+                "symfony/security": ">=2,<2.7.51|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.8",
+                "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<3.4.49|>=4,<4.4.24|>=5,<5.2.9",
+                "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/security-guard": ">=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8",
+                "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<3.4.48|>=4,<4.4.23|>=5,<5.2.8|>=5.3,<5.3.2",
+                "symfony/serializer": ">=2,<2.0.11",
+                "symfony/symfony": ">=2,<3.4.49|>=4,<4.4.24|>=5,<5.2.9|>=5.3,<5.3.2",
+                "symfony/translation": ">=2,<2.0.17",
+                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
+                "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
+                "t3/dce": ">=2.2,<2.6.2",
+                "t3g/svg-sanitizer": "<1.0.3",
+                "tecnickcom/tcpdf": "<6.2.22",
+                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1-beta.1,<2.1.3",
+                "theonedemon/phpwhois": "<=4.2.5",
+                "titon/framework": ">=0,<9.9.99",
+                "topthink/think": "<=6.0.9",
+                "tribalsystems/zenario": "<8.8.53370",
+                "truckersmp/phpwhois": "<=4.3.1",
+                "twig/twig": "<1.38|>=2,<2.7",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.3.2",
+                "typo3/cms-backend": ">=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
+                "typo3/cms-core": ">=6.2,<=6.2.56|>=7,<=7.6.52|>=8,<=8.7.41|>=9,<9.5.29|>=10,<10.4.19|>=11,<11.3.2",
+                "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.13|>=11,<=11.1",
+                "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
+                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
+                "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+                "typo3/swiftmailer": ">=4.1,<4.1.99|>=5.4,<5.4.5",
+                "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
+                "ua-parser/uap-php": "<3.8",
+                "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+                "vanilla/safecurl": "<0.9.2",
+                "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
+                "vrana/adminer": "<4.7.9",
+                "wallabag/tcpdf": "<6.2.22",
+                "webcoast/deferred-image-processing": "<1.0.2",
+                "wikimedia/parsoid": "<0.12.2",
+                "willdurand/js-translation-bundle": "<2.1.1",
+                "wp-cli/wp-cli": "<2.5",
+                "yidashi/yii2cmf": "<=2",
+                "yii2mod/yii2-cms": "<1.9.2",
+                "yiisoft/yii": ">=1.1.14,<1.1.15",
+                "yiisoft/yii2": "<2.0.38",
+                "yiisoft/yii2-bootstrap": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.43",
+                "yiisoft/yii2-elasticsearch": "<2.0.5",
+                "yiisoft/yii2-gii": "<2.0.4",
+                "yiisoft/yii2-jui": "<2.0.4",
+                "yiisoft/yii2-redis": "<2.0.8",
+                "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
+                "yourls/yourls": "<=1.8.2",
+                "zendesk/zendesk_api_client_php": "<2.2.11",
+                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
+                "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+                "zendframework/zend-diactoros": ">=1,<1.8.4",
+                "zendframework/zend-feed": ">=1,<2.10.3",
+                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-http": ">=1,<2.8.1",
+                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+                "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
+                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
+                "zendframework/zend-validator": ">=2.3,<2.3.6",
+                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+                "zendframework/zendframework": "<=3",
+                "zendframework/zendframework1": "<1.12.20",
+                "zendframework/zendopenid": ">=2,<2.0.2",
+                "zendframework/zendxml": ">=1,<1.0.1",
+                "zetacomponents/mail": "<1.8.2",
+                "zf-commons/zfc-user": "<1.2.2",
+                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+                "zfr/zfr-oauth2-server-module": "<0.1.2",
+                "zoujingli/thinkadmin": "<6.0.22"
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "role": "maintainer"
+                },
+                {
+                    "name": "Ilya Tribusean",
+                    "email": "slash3b@gmail.com",
+                    "role": "maintainer"
+                }
+            ],
+            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+            "support": {
+                "issues": "https://github.com/Roave/SecurityAdvisories/issues",
+                "source": "https://github.com/Roave/SecurityAdvisories/tree/latest"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-03T23:02:20+00:00"
+        },
+        {
+            "name": "sensiolabs/security-checker",
+            "version": "v5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sensiolabs/security-checker.git",
+                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
+                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "php": ">=5.5.9",
+                "symfony/console": "~2.7|~3.0|~4.0"
+            },
+            "bin": [
+                "security-checker"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SensioLabs\\Security\\": "SensioLabs/Security"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien.potencier@gmail.com"
+                }
+            ],
+            "description": "A security checker for your composer.lock",
+            "support": {
+                "issues": "https://github.com/sensiolabs/security-checker/issues",
+                "source": "https://github.com/sensiolabs/security-checker/tree/master"
+            },
+            "abandoned": "https://github.com/fabpot/local-php-security-checker",
+            "time": "2018-12-19T17:14:59+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2020-10-23T02:01:07+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.4.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c98349bda966c70d6c08b4cd8658377c94166492"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c98349bda966c70d6c08b4cd8658377c94166492",
+                "reference": "c98349bda966c70d6c08b4cd8658377c94166492",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v4.4.20"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-22T18:44:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "roave/security-advisories": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": {
+        "php": ">=7.4.0"
+    },
+    "platform-overrides": {
+        "php": "7.4"
+    },
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1230 @@
+{
+  "_readme": [
+      "This file locks the dependencies of your project to a known state",
+      "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+      "This file is @generated automatically"
+  ],
+  "content-hash": "d3b55e9ba9b5e39afeb0cd567e0d0424",
+  "packages": [],
+  "packages-dev": [
+      {
+          "name": "composer/ca-bundle",
+          "version": "1.2.9",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/composer/ca-bundle.git",
+              "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+              "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+              "shasum": ""
+          },
+          "require": {
+              "ext-openssl": "*",
+              "ext-pcre": "*",
+              "php": "^5.3.2 || ^7.0 || ^8.0"
+          },
+          "require-dev": {
+              "phpstan/phpstan": "^0.12.55",
+              "psr/log": "^1.0",
+              "symfony/phpunit-bridge": "^4.2 || ^5",
+              "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-main": "1.x-dev"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Composer\\CaBundle\\": "src"
+              }
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Jordi Boggiano",
+                  "email": "j.boggiano@seld.be",
+                  "homepage": "http://seld.be"
+              }
+          ],
+          "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+          "keywords": [
+              "cabundle",
+              "cacert",
+              "certificate",
+              "ssl",
+              "tls"
+          ],
+          "funding": [
+              {
+                  "url": "https://packagist.com",
+                  "type": "custom"
+              },
+              {
+                  "url": "https://github.com/composer",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2021-01-12T12:10:35+00:00"
+      },
+      {
+          "name": "dealerdirect/phpcodesniffer-composer-installer",
+          "version": "v0.7.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+              "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+              "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+              "shasum": ""
+          },
+          "require": {
+              "composer-plugin-api": "^1.0 || ^2.0",
+              "php": ">=5.3",
+              "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+          },
+          "require-dev": {
+              "composer/composer": "*",
+              "phpcompatibility/php-compatibility": "^9.0",
+              "sensiolabs/security-checker": "^4.1.0"
+          },
+          "type": "composer-plugin",
+          "extra": {
+              "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+          },
+          "autoload": {
+              "psr-4": {
+                  "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+              }
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Franck Nijhof",
+                  "email": "franck.nijhof@dealerdirect.com",
+                  "homepage": "http://www.frenck.nl",
+                  "role": "Developer / IT Manager"
+              }
+          ],
+          "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+          "homepage": "http://www.dealerdirect.com",
+          "keywords": [
+              "PHPCodeSniffer",
+              "PHP_CodeSniffer",
+              "code quality",
+              "codesniffer",
+              "composer",
+              "installer",
+              "phpcs",
+              "plugin",
+              "qa",
+              "quality",
+              "standard",
+              "standards",
+              "style guide",
+              "stylecheck",
+              "tests"
+          ],
+          "time": "2020-12-07T18:04:37+00:00"
+      },
+      {
+          "name": "phpcompatibility/php-compatibility",
+          "version": "9.3.5",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+              "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+              "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=5.3",
+              "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+          },
+          "conflict": {
+              "squizlabs/php_codesniffer": "2.6.2"
+          },
+          "require-dev": {
+              "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+          },
+          "suggest": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+              "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+          },
+          "type": "phpcodesniffer-standard",
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "LGPL-3.0-or-later"
+          ],
+          "authors": [
+              {
+                  "name": "Wim Godden",
+                  "homepage": "https://github.com/wimg",
+                  "role": "lead"
+              },
+              {
+                  "name": "Juliette Reinders Folmer",
+                  "homepage": "https://github.com/jrfnl",
+                  "role": "lead"
+              },
+              {
+                  "name": "Contributors",
+                  "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+              }
+          ],
+          "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+          "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+          "keywords": [
+              "compatibility",
+              "phpcs",
+              "standards"
+          ],
+          "time": "2019-12-27T09:44:58+00:00"
+      },
+      {
+          "name": "phpcompatibility/phpcompatibility-paragonie",
+          "version": "1.3.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+              "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+              "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+              "shasum": ""
+          },
+          "require": {
+              "phpcompatibility/php-compatibility": "^9.0"
+          },
+          "require-dev": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+              "paragonie/random_compat": "dev-master",
+              "paragonie/sodium_compat": "dev-master"
+          },
+          "suggest": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+              "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+          },
+          "type": "phpcodesniffer-standard",
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "LGPL-3.0-or-later"
+          ],
+          "authors": [
+              {
+                  "name": "Wim Godden",
+                  "role": "lead"
+              },
+              {
+                  "name": "Juliette Reinders Folmer",
+                  "role": "lead"
+              }
+          ],
+          "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+          "homepage": "http://phpcompatibility.com/",
+          "keywords": [
+              "compatibility",
+              "paragonie",
+              "phpcs",
+              "polyfill",
+              "standards"
+          ],
+          "time": "2021-02-15T10:24:51+00:00"
+      },
+      {
+          "name": "phpcompatibility/phpcompatibility-wp",
+          "version": "2.1.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+              "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+              "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+              "shasum": ""
+          },
+          "require": {
+              "phpcompatibility/php-compatibility": "^9.0",
+              "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+          },
+          "require-dev": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+          },
+          "suggest": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+              "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+          },
+          "type": "phpcodesniffer-standard",
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "LGPL-3.0-or-later"
+          ],
+          "authors": [
+              {
+                  "name": "Wim Godden",
+                  "role": "lead"
+              },
+              {
+                  "name": "Juliette Reinders Folmer",
+                  "role": "lead"
+              }
+          ],
+          "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+          "homepage": "http://phpcompatibility.com/",
+          "keywords": [
+              "compatibility",
+              "phpcs",
+              "standards",
+              "wordpress"
+          ],
+          "time": "2021-02-15T12:58:46+00:00"
+      },
+      {
+          "name": "psr/container",
+          "version": "1.1.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/php-fig/container.git",
+              "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+              "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=7.2.0"
+          },
+          "type": "library",
+          "autoload": {
+              "psr-4": {
+                  "Psr\\Container\\": "src/"
+              }
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "PHP-FIG",
+                  "homepage": "https://www.php-fig.org/"
+              }
+          ],
+          "description": "Common Container Interface (PHP FIG PSR-11)",
+          "homepage": "https://github.com/php-fig/container",
+          "keywords": [
+              "PSR-11",
+              "container",
+              "container-interface",
+              "container-interop",
+              "psr"
+          ],
+          "time": "2021-03-05T17:36:06+00:00"
+      },
+      {
+          "name": "roave/security-advisories",
+          "version": "dev-master",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/Roave/SecurityAdvisories.git",
+              "reference": "0745f820eed6cb92603ca44a9c137ff8ce315e86"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0745f820eed6cb92603ca44a9c137ff8ce315e86",
+              "reference": "0745f820eed6cb92603ca44a9c137ff8ce315e86",
+              "shasum": ""
+          },
+          "conflict": {
+              "3f/pygmentize": "<1.2",
+              "adodb/adodb-php": "<5.20.12",
+              "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
+              "amphp/artax": "<1.0.6|>=2,<2.0.6",
+              "amphp/http": "<1.0.1",
+              "amphp/http-client": ">=4,<4.4",
+              "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6",
+              "asymmetricrypt/asymmetricrypt": ">=0,<9.9.99",
+              "aws/aws-sdk-php": ">=3,<3.2.1",
+              "bagisto/bagisto": "<0.1.5",
+              "barrelstrength/sprout-base-email": "<1.2.7",
+              "barrelstrength/sprout-forms": "<3.9",
+              "baserproject/basercms": ">=4,<=4.3.6|>=4.4,<4.4.1",
+              "bolt/bolt": "<3.7.1",
+              "bolt/core": "<4.1.13",
+              "brightlocal/phpwhois": "<=4.2.5",
+              "buddypress/buddypress": "<5.1.2",
+              "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+              "cakephp/cakephp": ">=1.3,<1.3.18|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=2.7,<2.7.6|>=3,<3.5.18|>=3.6,<3.6.15|>=3.7,<3.7.7",
+              "cart2quote/module-quotation": ">=4.1.6,<=4.4.5|>=5,<5.4.4",
+              "cartalyst/sentry": "<=2.1.6",
+              "centreon/centreon": "<18.10.8|>=19,<19.4.5",
+              "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
+              "codeigniter/framework": "<=3.0.6",
+              "composer/composer": "<=1-alpha.11",
+              "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+              "contao/core": ">=2,<3.5.39",
+              "contao/core-bundle": ">=4,<4.4.52|>=4.5,<4.9.6|= 4.10.0",
+              "contao/listing-bundle": ">=4,<4.4.8",
+              "datadog/dd-trace": ">=0.30,<0.30.2",
+              "david-garcia/phpwhois": "<=4.3.1",
+              "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
+              "doctrine/annotations": ">=1,<1.2.7",
+              "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
+              "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
+              "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
+              "doctrine/doctrine-bundle": "<1.5.2",
+              "doctrine/doctrine-module": "<=0.7.1",
+              "doctrine/mongodb-odm": ">=1,<1.0.2",
+              "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
+              "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
+              "dolibarr/dolibarr": "<11.0.4",
+              "dompdf/dompdf": ">=0.6,<0.6.2",
+              "drupal/core": ">=7,<7.74|>=8,<8.8.11|>=8.9,<8.9.9|>=9,<9.0.8",
+              "drupal/drupal": ">=7,<7.74|>=8,<8.8.11|>=8.9,<8.9.9|>=9,<9.0.8",
+              "endroid/qr-code-bundle": "<3.4.2",
+              "enshrined/svg-sanitize": "<0.13.1",
+              "erusev/parsedown": "<1.7.2",
+              "ezsystems/demobundle": ">=5.4,<5.4.6.1",
+              "ezsystems/ez-support-tools": ">=2.2,<2.2.3",
+              "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
+              "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
+              "ezsystems/ezplatform": ">=1.7,<1.7.9.1|>=1.13,<1.13.5.1|>=2.5,<2.5.4",
+              "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
+              "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+              "ezsystems/ezplatform-kernel": ">=1,<1.0.2.1",
+              "ezsystems/ezplatform-user": ">=1,<1.0.1",
+              "ezsystems/ezpublish-kernel": ">=5.3,<5.3.12.1|>=5.4,<5.4.14.2|>=6,<6.7.9.1|>=6.8,<6.13.6.3|>=7,<7.2.4.1|>=7.3,<7.3.2.1|>=7.5,<7.5.7.1",
+              "ezsystems/ezpublish-legacy": ">=5.3,<5.3.12.6|>=5.4,<5.4.14.2|>=2011,<2017.12.7.3|>=2018.6,<2018.6.1.4|>=2018.9,<2018.9.1.3|>=2019.3,<2019.3.5.1",
+              "ezsystems/platform-ui-assets-bundle": ">=4.2,<4.2.3",
+              "ezsystems/repository-forms": ">=2.3,<2.3.2.1",
+              "ezyang/htmlpurifier": "<4.1.1",
+              "facade/ignition": "<=2.5.1,>=2.0|<=1.16.13",
+              "firebase/php-jwt": "<2",
+              "flarum/sticky": ">=0.1-beta.14,<=0.1-beta.15",
+              "flarum/tags": "<=0.1-beta.13",
+              "fooman/tcpdf": "<6.2.22",
+              "fossar/tcpdf-parser": "<6.2.22",
+              "friendsofsymfony/oauth2-php": "<1.3",
+              "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
+              "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
+              "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
+              "fuel/core": "<1.8.1",
+              "getgrav/grav": "<1.7-beta.8",
+              "getkirby/cms": ">=3,<3.4.5",
+              "getkirby/panel": "<2.5.14",
+              "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
+              "gree/jose": "<=2.2",
+              "gregwar/rst": "<1.0.3",
+              "guzzlehttp/guzzle": ">=4-rc.2,<4.2.4|>=5,<5.3.1|>=6,<6.2.1",
+              "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
+              "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.99999|>=4.2,<=4.2.99999|>=5,<=5.0.99999|>=5.1,<=5.1.99999|>=5.2,<=5.2.99999|>=5.3,<=5.3.99999|>=5.4,<=5.4.99999|>=5.5,<=5.5.49|>=5.6,<=5.6.99999|>=5.7,<=5.7.99999|>=5.8,<=5.8.99999|>=6,<6.18.31|>=7,<7.22.4",
+              "illuminate/database": "<6.20.14|>=7,<7.30.4|>=8,<8.24",
+              "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+              "illuminate/view": ">=7,<7.1.2",
+              "ivankristianto/phpwhois": "<=4.3",
+              "james-heinrich/getid3": "<1.9.9",
+              "joomla/session": "<1.3.1",
+              "jsmitty12/phpwhois": "<5.1",
+              "kazist/phpwhois": "<=4.2.6",
+              "kitodo/presentation": "<3.1.2",
+              "kreait/firebase-php": ">=3.2,<3.8.1",
+              "la-haute-societe/tcpdf": "<6.2.22",
+              "laravel/framework": "<6.20.14|>=7,<7.30.4|>=8,<8.24",
+              "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
+              "league/commonmark": "<0.18.3",
+              "librenms/librenms": "<1.53",
+              "livewire/livewire": ">2.2.4,<2.2.6",
+              "magento/community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
+              "magento/magento1ce": "<1.9.4.3",
+              "magento/magento1ee": ">=1,<1.14.4.3",
+              "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2-p.2",
+              "marcwillmann/turn": "<0.3.3",
+              "mautic/core": "<2.16.5|>=3,<3.2.4|= 2.13.1",
+              "mediawiki/core": ">=1.27,<1.27.6|>=1.29,<1.29.3|>=1.30,<1.30.2|>=1.31,<1.31.9|>=1.32,<1.32.6|>=1.32.99,<1.33.3|>=1.33.99,<1.34.3|>=1.34.99,<1.35",
+              "mittwald/typo3_forum": "<1.2.1",
+              "monolog/monolog": ">=1.8,<1.12",
+              "namshi/jose": "<2.2",
+              "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
+              "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
+              "nystudio107/craft-seomatic": "<3.3",
+              "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
+              "october/backend": ">=1.0.319,<1.0.470",
+              "october/cms": "= 1.0.469|>=1.0.319,<1.0.469",
+              "october/october": ">=1.0.319,<1.0.466",
+              "october/rain": "<1.0.472|>=1.1,<1.1.2",
+              "onelogin/php-saml": "<2.10.4",
+              "oneup/uploader-bundle": "<1.9.3|>=2,<2.1.5",
+              "openid/php-openid": "<2.3",
+              "openmage/magento-lts": "<19.4.8|>=20,<20.0.4",
+              "orchid/platform": ">=9,<9.4.4",
+              "oro/crm": ">=1.7,<1.7.4",
+              "oro/platform": ">=1.7,<1.7.4",
+              "padraic/humbug_get_contents": "<1.1.2",
+              "pagarme/pagarme-php": ">=0,<3",
+              "paragonie/random_compat": "<2",
+              "passbolt/passbolt_api": "<2.11",
+              "paypal/merchant-sdk-php": "<3.12",
+              "pear/archive_tar": "<1.4.12",
+              "personnummer/personnummer": "<3.0.2",
+              "phpfastcache/phpfastcache": ">=5,<5.0.13",
+              "phpmailer/phpmailer": "<6.1.6",
+              "phpmussel/phpmussel": ">=1,<1.6",
+              "phpmyadmin/phpmyadmin": "<4.9.6|>=5,<5.0.3",
+              "phpoffice/phpexcel": "<1.8.2",
+              "phpoffice/phpspreadsheet": "<1.16",
+              "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
+              "phpwhois/phpwhois": "<=4.2.5",
+              "phpxmlrpc/extras": "<0.6.1",
+              "pimcore/pimcore": "<6.8.8",
+              "pocketmine/pocketmine-mp": "<3.15.4",
+              "prestashop/autoupgrade": ">=4,<4.10.1",
+              "prestashop/contactform": ">1.0.1,<4.3",
+              "prestashop/gamification": "<2.3.2",
+              "prestashop/productcomments": ">=4,<4.2.1",
+              "prestashop/ps_facetedsearch": "<3.4.1",
+              "privatebin/privatebin": "<1.2.2|>=1.3,<1.3.2",
+              "propel/propel": ">=2-alpha.1,<=2-alpha.7",
+              "propel/propel1": ">=1,<=1.7.1",
+              "pterodactyl/panel": "<0.7.19|>=1-rc.0,<=1-rc.6",
+              "pusher/pusher-php-server": "<2.2.1",
+              "rainlab/debugbar-plugin": "<3.1",
+              "robrichards/xmlseclibs": "<3.0.4",
+              "sabberworm/php-css-parser": ">=1,<1.0.1|>=2,<2.0.1|>=3,<3.0.1|>=4,<4.0.1|>=5,<5.0.9|>=5.1,<5.1.3|>=5.2,<5.2.1|>=6,<6.0.2|>=7,<7.0.4|>=8,<8.0.1|>=8.1,<8.1.1|>=8.2,<8.2.1|>=8.3,<8.3.1",
+              "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
+              "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
+              "sensiolabs/connect": "<4.2.3",
+              "serluck/phpwhois": "<=4.2.6",
+              "shopware/core": "<=6.3.4",
+              "shopware/platform": "<=6.3.5",
+              "shopware/shopware": "<5.6.9",
+              "silverstripe/admin": ">=1.0.3,<1.0.4|>=1.1,<1.1.1",
+              "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
+              "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
+              "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
+              "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
+              "silverstripe/framework": "<4.4.7|>=4.5,<4.5.4",
+              "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.1.2|>=3.2,<3.2.4",
+              "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
+              "silverstripe/restfulserver": ">=1,<1.0.9|>=2,<2.0.4",
+              "silverstripe/subsites": ">=2,<2.1.1",
+              "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
+              "silverstripe/userforms": "<3",
+              "simple-updates/phpwhois": "<=1",
+              "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
+              "simplesamlphp/simplesamlphp": "<1.18.6",
+              "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
+              "simplito/elliptic-php": "<1.0.6",
+              "slim/slim": "<2.6",
+              "smarty/smarty": "<3.1.39",
+              "socalnick/scn-social-auth": "<1.15.2",
+              "socialiteproviders/steam": "<1.1",
+              "spoonity/tcpdf": "<6.2.22",
+              "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
+              "ssddanbrown/bookstack": "<0.29.2",
+              "stormpath/sdk": ">=0,<9.9.99",
+              "studio-42/elfinder": "<2.1.49",
+              "sulu/sulu": "<1.6.34|>=2,<2.0.10|>=2.1,<2.1.1",
+              "swiftmailer/swiftmailer": ">=4,<5.4.5",
+              "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+              "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+              "sylius/grid-bundle": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
+              "sylius/resource-bundle": "<1.3.14|>=1.4,<1.4.7|>=1.5,<1.5.2|>=1.6,<1.6.4",
+              "sylius/sylius": "<1.6.9|>=1.7,<1.7.9|>=1.8,<1.8.3",
+              "symbiote/silverstripe-multivaluefield": ">=3,<3.0.99",
+              "symbiote/silverstripe-versionedfiles": "<=2.0.3",
+              "symfony/cache": ">=3.1,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
+              "symfony/dependency-injection": ">=2,<2.0.17|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+              "symfony/error-handler": ">=4.4,<4.4.4|>=5,<5.0.4",
+              "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.50|>=2.8,<2.8.49|>=3,<3.4.20|>=4,<4.0.15|>=4.1,<4.1.9|>=4.2,<4.2.1",
+              "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2|>=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+              "symfony/http-foundation": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+              "symfony/http-kernel": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
+              "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
+              "symfony/mime": ">=4.3,<4.3.8",
+              "symfony/phpunit-bridge": ">=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+              "symfony/polyfill": ">=1,<1.10",
+              "symfony/polyfill-php55": ">=1,<1.10",
+              "symfony/proxy-manager-bridge": ">=2.7,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+              "symfony/routing": ">=2,<2.0.19",
+              "symfony/security": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7|>=4.4,<4.4.7|>=5,<5.0.7",
+              "symfony/security-bundle": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+              "symfony/security-core": ">=2.4,<2.6.13|>=2.7,<2.7.9|>=2.7.30,<2.7.32|>=2.8,<2.8.37|>=3,<3.3.17|>=3.4,<3.4.7|>=4,<4.0.7",
+              "symfony/security-csrf": ">=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+              "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+              "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8|>=4.4,<4.4.7|>=5,<5.0.7",
+              "symfony/serializer": ">=2,<2.0.11",
+              "symfony/symfony": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.4.13|>=5,<5.1.5",
+              "symfony/translation": ">=2,<2.0.17",
+              "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
+              "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
+              "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
+              "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
+              "t3g/svg-sanitizer": "<1.0.3",
+              "tecnickcom/tcpdf": "<6.2.22",
+              "thelia/backoffice-default-template": ">=2.1,<2.1.2",
+              "thelia/thelia": ">=2.1-beta.1,<2.1.3",
+              "theonedemon/phpwhois": "<=4.2.5",
+              "titon/framework": ">=0,<9.9.99",
+              "truckersmp/phpwhois": "<=4.3.1",
+              "twig/twig": "<1.38|>=2,<2.7",
+              "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.32|>=8,<8.7.38|>=9,<9.5.23|>=10,<10.4.10",
+              "typo3/cms-core": ">=8,<8.7.38|>=9,<9.5.23|>=10,<10.4.10",
+              "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
+              "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
+              "typo3/phar-stream-wrapper": ">=1,<2.1.1|>=3,<3.1.1",
+              "typo3fluid/fluid": ">=2,<2.0.8|>=2.1,<2.1.7|>=2.2,<2.2.4|>=2.3,<2.3.7|>=2.4,<2.4.4|>=2.5,<2.5.11|>=2.6,<2.6.10",
+              "ua-parser/uap-php": "<3.8",
+              "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
+              "verot/class.upload.php": "<=1.0.3|>=2,<=2.0.4",
+              "vrana/adminer": "<4.7.9",
+              "wallabag/tcpdf": "<6.2.22",
+              "willdurand/js-translation-bundle": "<2.1.1",
+              "yii2mod/yii2-cms": "<1.9.2",
+              "yiisoft/yii": ">=1.1.14,<1.1.15",
+              "yiisoft/yii2": "<2.0.38",
+              "yiisoft/yii2-bootstrap": "<2.0.4",
+              "yiisoft/yii2-dev": "<2.0.15",
+              "yiisoft/yii2-elasticsearch": "<2.0.5",
+              "yiisoft/yii2-gii": "<2.0.4",
+              "yiisoft/yii2-jui": "<2.0.4",
+              "yiisoft/yii2-redis": "<2.0.8",
+              "yourls/yourls": "<1.7.4",
+              "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
+              "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
+              "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
+              "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
+              "zendframework/zend-developer-tools": ">=1.2.2,<1.2.3",
+              "zendframework/zend-diactoros": ">=1,<1.8.4",
+              "zendframework/zend-feed": ">=1,<2.10.3",
+              "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
+              "zendframework/zend-http": ">=1,<2.8.1",
+              "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+              "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
+              "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
+              "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
+              "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
+              "zendframework/zend-validator": ">=2.3,<2.3.6",
+              "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
+              "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
+              "zendframework/zendframework": "<2.5.1",
+              "zendframework/zendframework1": "<1.12.20",
+              "zendframework/zendopenid": ">=2,<2.0.2",
+              "zendframework/zendxml": ">=1,<1.0.1",
+              "zetacomponents/mail": "<1.8.2",
+              "zf-commons/zfc-user": "<1.2.2",
+              "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
+              "zfr/zfr-oauth2-server-module": "<0.1.2"
+          },
+          "type": "metapackage",
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Marco Pivetta",
+                  "email": "ocramius@gmail.com",
+                  "role": "maintainer"
+              },
+              {
+                  "name": "Ilya Tribusean",
+                  "email": "slash3b@gmail.com",
+                  "role": "maintainer"
+              }
+          ],
+          "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
+          "funding": [
+              {
+                  "url": "https://github.com/Ocramius",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/roave/security-advisories",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2021-03-03T23:02:20+00:00"
+      },
+      {
+          "name": "sensiolabs/security-checker",
+          "version": "v5.0.3",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/sensiolabs/security-checker.git",
+              "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
+              "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
+              "shasum": ""
+          },
+          "require": {
+              "composer/ca-bundle": "^1.0",
+              "php": ">=5.5.9",
+              "symfony/console": "~2.7|~3.0|~4.0"
+          },
+          "bin": [
+              "security-checker"
+          ],
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-master": "5.0-dev"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "SensioLabs\\Security\\": "SensioLabs/Security"
+              }
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Fabien Potencier",
+                  "email": "fabien.potencier@gmail.com"
+              }
+          ],
+          "description": "A security checker for your composer.lock",
+          "abandoned": "https://github.com/fabpot/local-php-security-checker",
+          "time": "2018-12-19T17:14:59+00:00"
+      },
+      {
+          "name": "squizlabs/php_codesniffer",
+          "version": "3.5.8",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+              "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+              "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+              "shasum": ""
+          },
+          "require": {
+              "ext-simplexml": "*",
+              "ext-tokenizer": "*",
+              "ext-xmlwriter": "*",
+              "php": ">=5.4.0"
+          },
+          "require-dev": {
+              "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+          },
+          "bin": [
+              "bin/phpcs",
+              "bin/phpcbf"
+          ],
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-master": "3.x-dev"
+              }
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "BSD-3-Clause"
+          ],
+          "authors": [
+              {
+                  "name": "Greg Sherwood",
+                  "role": "lead"
+              }
+          ],
+          "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+          "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+          "keywords": [
+              "phpcs",
+              "standards"
+          ],
+          "time": "2020-10-23T02:01:07+00:00"
+      },
+      {
+          "name": "symfony/console",
+          "version": "v4.4.20",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/console.git",
+              "reference": "c98349bda966c70d6c08b4cd8658377c94166492"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/console/zipball/c98349bda966c70d6c08b4cd8658377c94166492",
+              "reference": "c98349bda966c70d6c08b4cd8658377c94166492",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=7.1.3",
+              "symfony/polyfill-mbstring": "~1.0",
+              "symfony/polyfill-php73": "^1.8",
+              "symfony/polyfill-php80": "^1.15",
+              "symfony/service-contracts": "^1.1|^2"
+          },
+          "conflict": {
+              "symfony/dependency-injection": "<3.4",
+              "symfony/event-dispatcher": "<4.3|>=5",
+              "symfony/lock": "<4.4",
+              "symfony/process": "<3.3"
+          },
+          "provide": {
+              "psr/log-implementation": "1.0"
+          },
+          "require-dev": {
+              "psr/log": "~1.0",
+              "symfony/config": "^3.4|^4.0|^5.0",
+              "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+              "symfony/event-dispatcher": "^4.3",
+              "symfony/lock": "^4.4|^5.0",
+              "symfony/process": "^3.4|^4.0|^5.0",
+              "symfony/var-dumper": "^4.3|^5.0"
+          },
+          "suggest": {
+              "psr/log": "For using the console logger",
+              "symfony/event-dispatcher": "",
+              "symfony/lock": "",
+              "symfony/process": ""
+          },
+          "type": "library",
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Component\\Console\\": ""
+              },
+              "exclude-from-classmap": [
+                  "/Tests/"
+              ]
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Fabien Potencier",
+                  "email": "fabien@symfony.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Eases the creation of beautiful and testable command line interfaces",
+          "homepage": "https://symfony.com",
+          "funding": [
+              {
+                  "url": "https://symfony.com/sponsor",
+                  "type": "custom"
+              },
+              {
+                  "url": "https://github.com/fabpot",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2021-02-22T18:44:15+00:00"
+      },
+      {
+          "name": "symfony/polyfill-mbstring",
+          "version": "v1.22.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/polyfill-mbstring.git",
+              "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+              "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=7.1"
+          },
+          "suggest": {
+              "ext-mbstring": "For best performance"
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-main": "1.22-dev"
+              },
+              "thanks": {
+                  "name": "symfony/polyfill",
+                  "url": "https://github.com/symfony/polyfill"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Polyfill\\Mbstring\\": ""
+              },
+              "files": [
+                  "bootstrap.php"
+              ]
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Nicolas Grekas",
+                  "email": "p@tchwork.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Symfony polyfill for the Mbstring extension",
+          "homepage": "https://symfony.com",
+          "keywords": [
+              "compatibility",
+              "mbstring",
+              "polyfill",
+              "portable",
+              "shim"
+          ],
+          "funding": [
+              {
+                  "url": "https://symfony.com/sponsor",
+                  "type": "custom"
+              },
+              {
+                  "url": "https://github.com/fabpot",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2021-01-22T09:19:47+00:00"
+      },
+      {
+          "name": "symfony/polyfill-php73",
+          "version": "v1.22.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/polyfill-php73.git",
+              "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+              "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=7.1"
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-main": "1.22-dev"
+              },
+              "thanks": {
+                  "name": "symfony/polyfill",
+                  "url": "https://github.com/symfony/polyfill"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Polyfill\\Php73\\": ""
+              },
+              "files": [
+                  "bootstrap.php"
+              ],
+              "classmap": [
+                  "Resources/stubs"
+              ]
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Nicolas Grekas",
+                  "email": "p@tchwork.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+          "homepage": "https://symfony.com",
+          "keywords": [
+              "compatibility",
+              "polyfill",
+              "portable",
+              "shim"
+          ],
+          "funding": [
+              {
+                  "url": "https://symfony.com/sponsor",
+                  "type": "custom"
+              },
+              {
+                  "url": "https://github.com/fabpot",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2021-01-07T16:49:33+00:00"
+      },
+      {
+          "name": "symfony/polyfill-php80",
+          "version": "v1.22.1",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/polyfill-php80.git",
+              "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+              "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=7.1"
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-main": "1.22-dev"
+              },
+              "thanks": {
+                  "name": "symfony/polyfill",
+                  "url": "https://github.com/symfony/polyfill"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Polyfill\\Php80\\": ""
+              },
+              "files": [
+                  "bootstrap.php"
+              ],
+              "classmap": [
+                  "Resources/stubs"
+              ]
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Ion Bazan",
+                  "email": "ion.bazan@gmail.com"
+              },
+              {
+                  "name": "Nicolas Grekas",
+                  "email": "p@tchwork.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+          "homepage": "https://symfony.com",
+          "keywords": [
+              "compatibility",
+              "polyfill",
+              "portable",
+              "shim"
+          ],
+          "funding": [
+              {
+                  "url": "https://symfony.com/sponsor",
+                  "type": "custom"
+              },
+              {
+                  "url": "https://github.com/fabpot",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2021-01-07T16:49:33+00:00"
+      },
+      {
+          "name": "symfony/service-contracts",
+          "version": "v2.2.0",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/symfony/service-contracts.git",
+              "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+              "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=7.2.5",
+              "psr/container": "^1.0"
+          },
+          "suggest": {
+              "symfony/service-implementation": ""
+          },
+          "type": "library",
+          "extra": {
+              "branch-alias": {
+                  "dev-master": "2.2-dev"
+              },
+              "thanks": {
+                  "name": "symfony/contracts",
+                  "url": "https://github.com/symfony/contracts"
+              }
+          },
+          "autoload": {
+              "psr-4": {
+                  "Symfony\\Contracts\\Service\\": ""
+              }
+          },
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Nicolas Grekas",
+                  "email": "p@tchwork.com"
+              },
+              {
+                  "name": "Symfony Community",
+                  "homepage": "https://symfony.com/contributors"
+              }
+          ],
+          "description": "Generic abstractions related to writing services",
+          "homepage": "https://symfony.com",
+          "keywords": [
+              "abstractions",
+              "contracts",
+              "decoupling",
+              "interfaces",
+              "interoperability",
+              "standards"
+          ],
+          "funding": [
+              {
+                  "url": "https://symfony.com/sponsor",
+                  "type": "custom"
+              },
+              {
+                  "url": "https://github.com/fabpot",
+                  "type": "github"
+              },
+              {
+                  "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                  "type": "tidelift"
+              }
+          ],
+          "time": "2020-09-07T11:33:47+00:00"
+      },
+      {
+          "name": "wp-coding-standards/wpcs",
+          "version": "2.3.0",
+          "source": {
+              "type": "git",
+              "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+              "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+          },
+          "dist": {
+              "type": "zip",
+              "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+              "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+              "shasum": ""
+          },
+          "require": {
+              "php": ">=5.4",
+              "squizlabs/php_codesniffer": "^3.3.1"
+          },
+          "require-dev": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+              "phpcompatibility/php-compatibility": "^9.0",
+              "phpcsstandards/phpcsdevtools": "^1.0",
+              "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+          },
+          "suggest": {
+              "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+          },
+          "type": "phpcodesniffer-standard",
+          "notification-url": "https://packagist.org/downloads/",
+          "license": [
+              "MIT"
+          ],
+          "authors": [
+              {
+                  "name": "Contributors",
+                  "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+              }
+          ],
+          "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+          "keywords": [
+              "phpcs",
+              "standards",
+              "wordpress"
+          ],
+          "time": "2020-05-13T23:57:56+00:00"
+      }
+  ],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": {
+      "roave/security-advisories": 20
+  },
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": [],
+  "platform-dev": {
+      "php": ">=7.3.0"
+  },
+  "platform-overrides": {
+      "php": "7.3"
+  },
+  "plugin-api-version": "1.1.0"
+}


### PR DESCRIPTION
This change adds in the required configuration to provide PHP/WordPress coding standards in developer IDEs. This provides immediate feedback and code formatting by IDEs which will reduce the back and forth of running a lint locally or online and having to go back in and fix code that does not meet standards.

Visual Studio Code Setup: https://github.com/tommcfarlin/phpcs-wpcs-vscode#6-update-user-settings
PhpStorm: https://www.jetbrains.com/help/phpstorm/using-php-code-sniffer.html#installing-configuring-code-sniffer