### PR TITLE
Fixes Frontpage Block Editor Functionalty & Cleans Up Code WhiteSpace

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -1,94 +1,93 @@
-{{ function('get_header') }}
+{{- function('get_header') }}
 
-{% block page %}
-  {% block html_head_container %}
-    {% include 'html-header.twig' %}
-  {% endblock %}
+{%- block page %}
+	{%~ block html_head_container %}
+	{%~ include 'html-header.twig' %}
+	{%~ endblock %}
 
-  {% set body_id = 'body_top' %}
+	{%- set body_id = 'body_top' %}
+	<!-- Provided by templates/base.twig -->
+	<body {{ function('body_class')}} id="{{ body_id }}">
 
-  <!-- Provided by templates/base.twig -->
-  <body {{ function('body_class')}} id="{{ body_id }}">
+		{%- block skiplinks %}
+		  {% include '@components/skiplinks/skiplinks.twig' %}
+		{%- endblock %}
 
-    {% block skiplinks %}
-      {% include '@components/skiplinks/skiplinks.twig' %}
-    {% endblock %}
+		{# set the content of the site as a variable to be passed to site-container.twig #}
+		{% set site_content %}
 
-    {# set the content of the site as a variable to be passed to site-container.twig #}
-    {% set site_content %}
+		  {% embed '@layouts/header/header.twig' with {
+			'has_constrain': true
+		  } %}
+			{% block content %}
+			  {% include '@components/site-name/site-name.twig' with {
+				'url': site.url,
+				'site_name': site.title
+			  } %}
+			{% endblock  %}
+		  {% endembed %}
 
-      {% embed '@layouts/header/header.twig' with {
-        'has_constrain': true
-      } %}
-        {% block content %}
-          {% include '@components/site-name/site-name.twig' with {
-            'url': site.url,
-            'site_name': site.title
-          } %}
-        {% endblock  %}
-      {% endembed %}
+		  {% embed '@layouts/region/region.twig' with {
+			'region_name': 'navigation',
+			'has_constrain': true
+		  } %}
+			{% block content %}
+			  {% include '@components/menu/menu.twig' with {
+				'items': primary_menu.items,
+				'menu_name': 'main'
+			  } %}
+			{% endblock  %}
+		  {% endembed %}
 
-      {% embed '@layouts/region/region.twig' with {
-        'region_name': 'navigation',
-        'has_constrain': true
-      } %}
-        {% block content %}
-          {% include '@components/menu/menu.twig' with {
-            'items': primary_menu.items,
-            'menu_name': 'main'
-          } %}
-        {% endblock  %}
-      {% endembed %}
+		  <main id="main" class="main" role="main" tabindex="-1">
+			{% embed '@layouts/region/region.twig' with {
+			  'region_name': 'preface',
+			  'has_constrain': true
+			} %}
+			  {% block content %}
+			  {% endblock %}
+			{% endembed %}
 
-      <main id="main" class="main" role="main" tabindex="-1">
-        {% embed '@layouts/region/region.twig' with {
-          'region_name': 'preface',
-          'has_constrain': true
-        } %}
-          {% block content %}
-          {% endblock %}
-        {% endembed %}
+			{% block content %}
+			  {% embed '@layouts/content/content.twig' with {
+				'has_constrain': true
+			  } %}
+				{% block content %}
+				{% endblock %}
+			  {% endembed %}
+			{% endblock %}
 
-        {% block content %}
-          {% embed '@layouts/content/content.twig' with {
-            'has_constrain': true
-          } %}
-            {% block content %}
-            {% endblock %}
-          {% endembed %}
-        {% endblock %}
+			{% embed '@layouts/region/region.twig' with {
+			  'region_name': 'postscript',
+			  'has_constrain': true
+			} %}
+			  {% block content %}
+			  {% endblock %}
+			{% endembed %}
+		  </main>
 
-        {% embed '@layouts/region/region.twig' with {
-          'region_name': 'postscript',
-          'has_constrain': true
-        } %}
-          {% block content %}
-          {% endblock %}
-        {% endembed %}
-      </main>
+		  {% block footer %}
+			{% include 'footer.twig' %}
+		  {% endblock %}
 
-      {% block footer %}
-        {% include 'footer.twig' %}
-      {% endblock %}
+		{% endset %}
 
-    {% endset %}
+		{% embed '@layouts/site-container/site-container.twig' %}
+		  {% block site_content %}
+			{{ site_content }}
+		  {% endblock %}
+		{% endembed %}
 
-    {% embed '@layouts/site-container/site-container.twig' %}
-      {% block site_content %}
-        {{ site_content }}
-      {% endblock %}
-    {% endembed %}
+		{% include '@components/back-to-top/back-to-top.twig' with {
+		  text: 'Back to top',
+		  top_element: body_id,
+		  gesso_image_path: gesso_image_path,
+		} %}
 
-    {% include '@components/back-to-top/back-to-top.twig' with {
-      text: 'Back to top',
-      top_element: body_id,
-      gesso_image_path: gesso_image_path,
-    } %}
-
-    {% block javascripts %}
-    {% endblock %}
-    {{ function('wp_footer') }}
-  </body>
-  </html>
-{% endblock %}
-{{ function('get_footer') }}
+		{% block javascripts %}
+		{% endblock %}
+		{{ function('wp_footer') }}
+	</body>
+</html>
+{%- endblock %}
+{{- function('get_footer') }}

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -1,5 +1,5 @@
 <!-- Provided by templates/footer.twig -->
-{% embed '@layouts/footer/footer.twig' with {
+{%- embed '@layouts/footer/footer.twig' with {
 	'has_constrain': true
 } %}
 	{% block content %}

--- a/templates/front-page.twig
+++ b/templates/front-page.twig
@@ -6,8 +6,13 @@
     'has_constrain': true
   } %}
     {% block content %}
-      {% include 'templates/components/loop.twig' %}
-      {% include '@components/pager/pager.twig' %}
+		{% if fn('is_home') == true %}
+			{% include 'templates/components/loop.twig' %}
+			{% include '@components/pager/pager.twig' %}
+		{% endif %}
+		{% if fn('is_home') == false %}
+			{{ post.content }}
+		{% endif %}
     {% endblock %}
   {% endembed %}
 {% endblock %}

--- a/templates/html-header.twig
+++ b/templates/html-header.twig
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html {{ site.language_attributes }} class="no-js"> 
-<head>
-	<meta charset="{{ site.charset }}" />
-	<link href="{{ site.theme.link }}/images/favicon.ico" rel="shortcut icon">
-	<meta name="HandheldFriendly" content="true">
-	<meta name="MobileOptimized" content="width">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="cleartype" content="on">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="description" content="{{ site.description }}">
-	{{ function('wp_head') }}
-</head>
+<html {{ site.language_attributes }} class="no-js">
+	<head>
+		<meta charset="{{ site.charset }}" />
+		<link href="{{ site.theme.link }}/images/favicon.ico" rel="shortcut icon">
+		<meta name="HandheldFriendly" content="true">
+		<meta name="MobileOptimized" content="width">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta http-equiv="cleartype" content="on">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="description" content="{{ site.description }}">
+		{{ function('wp_head') }}
+	</head>

--- a/templates/page-plugin.twig
+++ b/templates/page-plugin.twig
@@ -1,5 +1,5 @@
-{% extends 'base.twig' %}
+{%- extends 'base.twig' %}
 
-{% block page %}
-  {{ content }}
-{% endblock %}
+{%- block page %}
+  {{- content }}
+{%- endblock %}


### PR DESCRIPTION
* Adds in checks for the `front-page` Twig template in order to properly output page Block Editor content when a Page is set as the static Front Page.
* Addresses a lot of whitespace in the generated HTML markup caused by Twig templates.
