### PR TITLE
Change themeStyles property to editorStyles

### DIFF
--- a/.blockbook/index.js
+++ b/.blockbook/index.js
@@ -13,7 +13,7 @@ import 'F1BlockLibrary/single-card';
 registerTheme({
 	name: 'gesso',
 	title: 'Gesso',
-	themeStyles,
+	editorStyles: themeStyles,
 });
 
 // Blocks


### PR DESCRIPTION
This should fix the missing styles in both the Editor and Example tabs.