### PR TITLE
Disable autofixing stylelint order

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -25,6 +25,7 @@ rules:
       - custom-properties
       - declarations
     - unspecified: ignore
+      disableFix: true
   order/properties-alphabetical-order: error
   # Results in false positives
   no-descending-specificity: null


### PR DESCRIPTION
Adds parity with Gesso 5 Drupal