### PR TITLE
[DEVTOOLS-584] Fixes Issues With Invalid Code for Linting & Run Standardization

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -314,66 +314,6 @@ if ( ! class_exists( 'Timber' ) ) {
 Timber::$dirname = array( 'templates' );
 
 /**
- * New site class extended from Timber.
- */
-class StarterSite extends TimberSite {
-
-	/**
-	 * Class constructor.
-	 */
-	public function __construct() {
-		// add_theme_support( 'post-formats' ); // uncomment to enable post formats.
-		add_theme_support( 'post-thumbnails' );
-		add_theme_support( 'menus' );
-		add_filter( 'timber/context', array( $this, 'add_to_context' ) );
-		add_filter( 'timber/twig', array( $this, 'add_to_twig' ) );
-		parent::__construct();
-	}
-
-	/**
-	 * Add items to Timber context.
-	 *
-	 * @param array $context The Timber context array.
-	 *
-	 * @return array The Timber context array.
-	 */
-	public function add_to_context( $context ) {
-		$context['foo'] = 'bar';
-		$context['stuff'] = 'I am a value set in your functions.php file';
-		$context['notes'] = 'These values are available everytime you call Timber::get_context();';
-		$context['primary_menu'] = new Timber\Menu( 'primary' );
-		$context['secondary_menu'] = new Timber\Menu( 'secondary' );
-		$context['menu'] = new Timber\Menu();
-		$context['current_year'] = gmdate( 'Y' );
-		$context['site'] = $this;
-		$context['gesso_image_path'] = get_template_directory_uri() . '/images';
-		return $context;
-	}
-
-	/**
-	 * Method used to add custom Twig functions.
-	 *
-	 * @param \Twig_Environment $twig The Twig object.
-	 *
-	 * @return \Twig_Environment
-	 */
-	public function add_to_twig( \Twig_Environment $twig ) {
-		/**
-		 * This is where you can add your own fuctions to twig.
-		 *
-		 * @see https://timber.github.io/docs/guides/extending-timber/#adding-to-twig
-		 */
-		$twig->addExtension( new \Twig_Extension_StringLoader() );
-		$twig->addFilter( new \Twig_SimpleFilter( 'myfoo', 'my_foo' ) );
-		return $twig;
-	}
-
-}
-
-new StarterSite();
-
-
-/**
  * Override default WordPress gallery markup, outputs in BEM format.
  *
  * @param string $gallery The gallery raw HTML.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "yaml": "1.10.0"
   },
   "scripts": {
-    "component": "node lib/component.js"
+    "component": "node lib/component.js",
+    "eslint": "eslint -c .eslintrc-dev.js \"**/*.es6.js\"",
+    "stylelint": "stylelint -f verbose \"source/**/*.scss\" --ip \"source/**/*.artifact.scss\""
   },
   "dependencies": {
     "custom-event-polyfill": "^1.0.7",


### PR DESCRIPTION
* Removes the invalid/unused StarterSite class in the `functions.php` file.
* Adds ESLint & StyleLint NPM scripts for linting runtime standardization.

Relates to this work: https://github.com/forumone/wordpress-project/pull/50