### PR TITLE
[DEVTOOLS-584] Adds Missing ESlint & StyleLint Standalone NPM Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "webpack --config ./webpack.theme-config.js && webpack --config ./webpack.dev.js",
     "build": "webpack --config ./webpack.theme-config.js && webpack --config ./webpack.production.js",
     "dev": "npm run start && concurrently --raw \"webpack watch --config ./webpack.dev.js\" \"webpack watch --config ./webpack.theme-config.js\"",
-    "rename": "node lib/rename.js"
+    "rename": "node lib/rename.js",
+    "eslint": "eslint -c .eslintrc.js \"**/*.es6.js\"",
+    "stylelint": "stylelint \"source/**/*.scss\""
   },
   "bugs": "https://github.com/forumone/gesso-wp/issues",
   "repository": {


### PR DESCRIPTION
* Updates the NPM package.json to include scripts for running ESlint and StyleLint independently from WebPack.

This is required for use by the WordPress Starter repo linting setup. https://github.com/forumone/wordpress-project/pull/50