### PR TITLE
Updates NPM Scripts to Account for Eslint Dev/Prod Configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
   },
   "scripts": {
     "component": "node lib/component.js",
-    "eslint": "eslint -c .eslintrc-dev.js \"**/*.es6.js\"",
+    "build": "gulp build",
+    "eslint": "eslint -c .eslintrc.js \"**/*.es6.js\"",
+    "eslint:dev": "eslint -c .eslintrc-dev.js \"**/*.es6.js\"",
     "stylelint": "stylelint -f verbose \"source/**/*.scss\" --ip \"source/**/*.artifact.scss\""
   },
   "dependencies": {


### PR DESCRIPTION
* Fixes #385
* Changes the `eslint` script to be production.
* Adds an `eslint:dev` script for doing local development ESlinting.
* Adds a `build` script to better align with Gesso 5 and updates in the WP Starter.
