### PR TITLE
Updates NPM Scripts to Include Standard Watch Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "npm run start && concurrently --raw \"webpack watch --config ./webpack.dev.js\" \"webpack watch --config ./webpack.theme-config.js\"",
     "rename": "node lib/rename.js",
     "eslint": "eslint -c .eslintrc.js \"**/*.es6.js\"",
-    "stylelint": "stylelint \"source/**/*.scss\""
+    "stylelint": "stylelint \"source/**/*.scss\"",
+    "watch": "npm run dev"
   },
   "bugs": "https://github.com/forumone/gesso-wp/issues",
   "repository": {


### PR DESCRIPTION
* Related to #396
* Updates the available NPM scripts to include a standard `watch` script to unify the call for the WordPress Starter Project.
