### PR TITLE
Updates Geso 4 NPM Script to Include Standard Watch Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "build": "gulp build",
     "eslint": "eslint -c .eslintrc.js \"**/*.es6.js\"",
     "eslint:dev": "eslint -c .eslintrc-dev.js \"**/*.es6.js\"",
-    "stylelint": "stylelint -f verbose \"source/**/*.scss\" --ip \"source/**/*.artifact.scss\""
+    "stylelint": "stylelint -f verbose \"source/**/*.scss\" --ip \"source/**/*.artifact.scss\"",
+    "watch": "gulp"
   },
   "dependencies": {
     "custom-event-polyfill": "^1.0.7",


### PR DESCRIPTION
* Fixes #396
* Updates the available NPM scripts to include a standard `watch` script to unify the call for the WordPress Starter Project.
